### PR TITLE
fix: ReferenceError - jest is not defined

### DIFF
--- a/src/api/methods/sendRawTransaction.js
+++ b/src/api/methods/sendRawTransaction.js
@@ -1,8 +1,6 @@
 const { Tx } = require('leap-core');
 const sendTx = require('../../txHelpers/sendTx');
 
-jest.mock('../../txHelpers/sendTx');
-
 module.exports = async (lotionPort, rawTx) => {
   const data = Buffer.from(rawTx.data);
   const tx = Tx.fromRaw(data);

--- a/src/api/methods/sendRawTransaction.test.js
+++ b/src/api/methods/sendRawTransaction.test.js
@@ -3,6 +3,8 @@ const sendRawTransaction = require('./sendRawTransaction');
 
 const A1 = '0xB8205608d54cb81f44F263bE086027D8610F3C94';
 
+jest.mock('../../txHelpers/sendTx');
+
 describe('sendRawTransaction', () => {
   test('success', async () => {
     const tx = Tx.deposit(0, 100, A1, 0);


### PR DESCRIPTION
Error on start

```
(node:74213) UnhandledPromiseRejectionWarning: ReferenceError: jest is not defined
    at Object.<anonymous> (/Users/troggy/projects/acebusters/parsec-node/src/api/methods/sendRawTransaction.js:4:1)
...
    at module.exports (/Users/troggy/projects/acebusters/parsec-node/src/api/methods/index.js:16:29)
    at module.exports (/Users/troggy/projects/acebusters/parsec-node/src/api/jsonrpc.js:27:44)
    at app.listen.then (/Users/troggy/projects/acebusters/parsec-node/index.js:96:23)
...
```