### PR TITLE
fix: broken net_version JSON RPC method

### DIFF
--- a/.config.json
+++ b/.config.json
@@ -3,5 +3,6 @@
   "rootNetwork": "https://rinkeby.infura.io",
   "genesis": null,
   "network": "",
+  "networkId": 1341,
   "peers": []
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Example: `DEBUG=tendermint,leap-node:tx leap-node`
 - `bridgeAddr` — leap bridge contract address
 - `rootNetwork` — ethereum provider url
 - `genesis` — genesis string
-- `network` — network id
+- `network` — network name
+- `networkId` - network ID. Possible values: `1340` - Leap mainnet, `1341` - Leap testnet.
 - `peers` — array of peers
 
 ### Config presets

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function run() {
         epochLengthIndex: -1,
       },
     },
-    networkId: config.network,
+    networkId: `${config.network}-${config.networkId}`,
     genesis: config.genesis,
     abciPort: 26658,
     peers: config.peers,

--- a/presets/leap-testnet-alpha.json
+++ b/presets/leap-testnet-alpha.json
@@ -2,6 +2,7 @@
   "bridgeAddr": "0x2dd9a878b9faecd0120dc53eda03547ca4eb5a93",
   "rootNetwork": "https://rinkeby.infura.io",
   "network": "leap-testnet-alpha",
+  "networkId": 1341,
   "genesis": {"app_hash":"2436cd126aca5c6ef46b17a041de5b935396224ce9fc2b9cc1f1a60bf52e317e","chain_id":"test-chain-ky8bNW","consensus_params":{"block_gossip_params":{"block_part_size_bytes":"65536"},"block_size_params":{"max_bytes":"22020096","max_gas":"-1","max_txs":"10000"},"evidence_params":{"max_age":"100000"},"tx_size_params":{"max_bytes":"10240","max_gas":"-1"}},"genesis_time":"2018-07-16T10:08:17.520479952Z","validators":[{"name":"","power":"10","pub_key":{"type":"tendermint/PubKeyEd25519","value":"dkDWnZ7bIVksvfTMSZVupT5ZZW/C2LvRrj9Ce/Z9R/o="}}]},
   "peers": [
     "b661fa5f8b1ef4207ac2ecb99bb6e126fd1252eb@testnet-1.leapdao.org:46691",

--- a/presets/leap-testnet-beta.json
+++ b/presets/leap-testnet-beta.json
@@ -2,6 +2,7 @@
   "bridgeAddr": "0x2ac21a06346f075cfa4c59779f85830356ea64f3",
   "rootNetwork": "https://rinkeby.infura.io",
   "network": "leap-testnet-beta",
+  "networkId": 1341,
   "genesis": {"app_hash":"2436cd126aca5c6ef46b17a041de5b935396224ce9fc2b9cc1f1a60bf52e317e","chain_id":"beta","consensus_params":{"block_gossip_params":{"block_part_size_bytes":"65536"},"block_size_params":{"max_bytes":"22020096","max_gas":"-1","max_txs":"10000"},"evidence_params":{"max_age":"100000"},"tx_size_params":{"max_bytes":"10240","max_gas":"-1"}},"genesis_time":"2018-07-16T10:08:17.520479952Z","validators":[{"name":"","power":"10","pub_key":{"type":"tendermint/PubKeyEd25519","value":"dkDWnZ7bIVksvfTMSZVupT5ZZW/C2LvRrj9Ce/Z9R/o="}}]},
   "peers": [
     "ac2d4601b740bbbc015a3c314e67ff4cb9ebc83c@testnet-1.leapdao.org:46691",

--- a/src/api/methods/getConfig.js
+++ b/src/api/methods/getConfig.js
@@ -3,6 +3,7 @@ module.exports = async bridgeState => {
     bridgeAddr: bridgeState.config.bridgeAddr,
     rootNetwork: bridgeState.config.rootNetwork,
     network: bridgeState.config.network,
+    networkId: bridgeState.config.networkId,
   };
 
   if (bridgeState.config.genesis) {

--- a/src/api/methods/getConfig.test.js
+++ b/src/api/methods/getConfig.test.js
@@ -8,11 +8,13 @@ describe('getConfig', () => {
       bridgeAddr: '0x186fab4587006032993a9abc62ab288cc259d7e7',
       rootNetwork: 'https://rinkeby.infura.io',
       network: 'testnet',
+      networkId: '1341',
     };
     const result = await getConfig({ config });
     expect(result.bridgeAddr).toBe(config.bridgeAddr);
     expect(result.rootNetwork).toBe(config.rootNetwork);
     expect(result.network).toBe(config.network);
+    expect(result.networkId).toBe(config.networkId);
     expect(result.hasOwnProperty('peers')).toBe(false);
     expect(result.hasOwnProperty('genesis')).toBe(false);
   });
@@ -22,6 +24,7 @@ describe('getConfig', () => {
       bridgeAddr: '0x186fab4587006032993a9abc62ab288cc259d7e7',
       rootNetwork: 'https://rinkeby.infura.io',
       network: 'testnet',
+      networkId: '1341',
       peers: ['peer1'],
       genesis: { validators: ['validator'] },
     };
@@ -29,6 +32,7 @@ describe('getConfig', () => {
     expect(result.bridgeAddr).toBe(config.bridgeAddr);
     expect(result.rootNetwork).toBe(config.rootNetwork);
     expect(result.network).toBe(config.network);
+    expect(result.networkId).toBe(config.networkId);
     expect(result.peers).toBe(config.peers);
     expect(result.genesis).toBe(config.genesis);
   });
@@ -38,6 +42,7 @@ describe('getConfig', () => {
       bridgeAddr: '0x186fab4587006032993a9abc62ab288cc259d7e7',
       rootNetwork: 'https://rinkeby.infura.io',
       network: 'testnet',
+      networkId: '1341',
       peers: ['peer1'],
       genesis: { validators: ['validator'] },
       privKey: '0x000000',
@@ -50,6 +55,7 @@ describe('getConfig', () => {
       'bridgeAddr',
       'rootNetwork',
       'network',
+      'networkId',
       'genesis',
       'peers',
     ]);

--- a/src/utils/printStartupInfo.js
+++ b/src/utils/printStartupInfo.js
@@ -63,4 +63,10 @@ module.exports = async (params, bridgeState) => {
     console.log(`  ${colors.bold('Validator ID:')}\t\t${validatorID}`);
     console.log('\n');
   }
+
+  logNode(
+    `Network: ${bridgeState.config.network}, Network ID: ${
+      bridgeState.networkId
+    }`
+  );
 };


### PR DESCRIPTION
Calling `web3.eth.net.getId` for Leap provider fails with:
```
Invalid JSON RPC response: {"jsonrpc":"2.0","id":1}
```

Few things were not right here:
- `bridgeState.networkId` was always [set](https://github.com/leapdao/leap-node/blob/master/src/bridgeState.js#L31) to `undefined`.
- `net_version` (aka `net.getId`) is [supposed](https://web3js.readthedocs.io/en/1.0/web3-net.html#getid) to return numeric value

Solution:
Proposing `networkId` — unique numeric value to indicate networkId. 
Possible values: `1340` for mainnet, `1341` for testnet (`134` for LEA 😎)
