### PR TITLE
make getTransaction JSON RPC compatible with Web3

### DIFF
--- a/src/api/methods/txResponse.js
+++ b/src/api/methods/txResponse.js
@@ -47,5 +47,7 @@ module.exports = async (db, tx, blockHash, height, txPos) => {
     to: tx.outputs && tx.outputs.length ? tx.outputs[0].address : null,
     gas: '0x0',
     gasPrice: '0x0',
+    nonce: 0,
+    input: '0x',
   };
 };

--- a/src/api/methods/txResponse.test.js
+++ b/src/api/methods/txResponse.test.js
@@ -51,6 +51,8 @@ describe('txResponse', () => {
       raw: tx.hex(),
       gas: '0x0',
       gasPrice: '0x0',
+      input: '0x',
+      nonce: 0,
     });
   });
 
@@ -92,6 +94,8 @@ describe('txResponse', () => {
       raw: tx.hex(),
       gas: '0x0',
       gasPrice: '0x0',
+      input: '0x',
+      nonce: 0,
     });
   });
 
@@ -132,6 +136,8 @@ describe('txResponse', () => {
       raw: tx.hex(),
       gas: '0x0',
       gasPrice: '0x0',
+      input: '0x',
+      nonce: 0,
     });
   });
 
@@ -159,6 +165,8 @@ describe('txResponse', () => {
       raw: tx.hex(),
       gas: '0x0',
       gasPrice: '0x0',
+      input: '0x',
+      nonce: 0,
     });
   });
 });


### PR DESCRIPTION
https://web3js.readthedocs.io/en/1.0/web3-eth.html#gettransaction

So that we can create typedef extended from `web3/Transaction`