### PR TITLE
follow RPC specification

### DIFF
--- a/src/api/methods/sendRawTransaction.js
+++ b/src/api/methods/sendRawTransaction.js
@@ -3,10 +3,6 @@ const sendTx = require('../../txHelpers/sendTx');
 
 module.exports = async (lotionPort, rawTx) => {
   const tx = Tx.fromRaw(rawTx);
-  try {
-    await sendTx(lotionPort, rawTx);
-    return tx.hash();
-  } catch (err) {
-    return err;
-  }
+  await sendTx(lotionPort, rawTx);
+  return tx.hash();
 };

--- a/src/api/methods/sendRawTransaction.js
+++ b/src/api/methods/sendRawTransaction.js
@@ -2,8 +2,11 @@ const { Tx } = require('leap-core');
 const sendTx = require('../../txHelpers/sendTx');
 
 module.exports = async (lotionPort, rawTx) => {
-  const data = Buffer.from(rawTx.data.replace('0x', ''), 'hex');
-  const tx = Tx.fromRaw(data);
-  await sendTx(lotionPort, `0x${data.toString('hex')}`);
-  return tx.hash();
+  const tx = Tx.fromRaw(rawTx);
+  try {
+    await sendTx(lotionPort, rawTx);
+    return tx.hash();
+  } catch (err) {
+    return err;
+  }
 };

--- a/src/api/methods/sendRawTransaction.test.js
+++ b/src/api/methods/sendRawTransaction.test.js
@@ -7,7 +7,7 @@ const A1 = '0xB8205608d54cb81f44F263bE086027D8610F3C94';
 jest.mock('axios');
 
 describe('sendRawTransaction', () => {
-  test('success', async () => {
+  test('success with hex', async () => {
     axios.post.mockImplementation(() => {
       return true;
     });
@@ -15,6 +15,16 @@ describe('sendRawTransaction', () => {
     const response = await sendRawTransaction(0, tx.hex());
     expect(response).toBe(tx.hash());
   });
+
+  test('success with buffer', async () => {
+    axios.post.mockImplementation(() => {
+      return true;
+    });
+    const tx = Tx.deposit(0, 100, A1, 0);
+    const response = await sendRawTransaction(0, tx.toRaw());
+    expect(response).toBe(tx.hash());
+  });
+
   test('error', async () => {
     const error = new Error();
     axios.post.mockImplementation(() => {

--- a/src/api/methods/sendRawTransaction.test.js
+++ b/src/api/methods/sendRawTransaction.test.js
@@ -1,14 +1,27 @@
+const axios = require('axios');
 const { Tx } = require('leap-core');
 const sendRawTransaction = require('./sendRawTransaction');
 
 const A1 = '0xB8205608d54cb81f44F263bE086027D8610F3C94';
 
-jest.mock('../../txHelpers/sendTx');
+jest.mock('axios');
 
 describe('sendRawTransaction', () => {
   test('success', async () => {
+    axios.post.mockImplementation(() => {
+      return true;
+    });
     const tx = Tx.deposit(0, 100, A1, 0);
-    const response = await sendRawTransaction(0, { data: tx.hex() });
+    const response = await sendRawTransaction(0, tx.hex());
     expect(response).toBe(tx.hash());
+  });
+  test('error', async () => {
+    const error = new Error();
+    axios.post.mockImplementation(() => {
+      throw error;
+    });
+    const tx = Tx.deposit(0, 100, A1, 0);
+    const response = await sendRawTransaction(0, tx.hex());
+    expect(response).toBe(error);
   });
 });

--- a/src/api/methods/sendRawTransaction.test.js
+++ b/src/api/methods/sendRawTransaction.test.js
@@ -21,7 +21,10 @@ describe('sendRawTransaction', () => {
       throw error;
     });
     const tx = Tx.deposit(0, 100, A1, 0);
-    const response = await sendRawTransaction(0, tx.hex());
-    expect(response).toBe(error);
+    try {
+      await sendRawTransaction(0, tx.hex());
+    } catch (err) {
+      expect(err).toBe(error);
+    }
   });
 });


### PR DESCRIPTION
- [x] remove wrapper object to follow specification as [in spec](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendrawtransaction).
- [x] add error test-case