### PR TITLE
make checkExit to handle exiting non-existing utxo

### DIFF
--- a/src/tx/applyTx/checkExit.js
+++ b/src/tx/applyTx/checkExit.js
@@ -22,6 +22,7 @@ module.exports = (state, tx, bridgeState) => {
   const unspent = state.unspent[prevout.hex()];
   const exit = bridgeState.exits[prevout.getUtxoId()];
   if (
+    !unspent ||
     !exit ||
     !addrCmp(exit.exitor, unspent.address) ||
     !equal(BigInt(exit.amount), BigInt(unspent.value)) ||

--- a/src/tx/applyTx/checkExit.test.js
+++ b/src/tx/applyTx/checkExit.test.js
@@ -49,7 +49,7 @@ describe('checkExit', () => {
     ).toThrow('Exit tx should have one input');
   });
 
-  test('non-existent', () => {
+  test('non-existent exit', () => {
     const deposit = Tx.deposit(12, 500, ADDR_1, 0);
     const outpoint = new Outpoint(deposit.hash(), 0);
     const state = {
@@ -60,6 +60,19 @@ describe('checkExit', () => {
     const exit = Tx.exit(new Input(outpoint));
     expect(() => {
       checkExit(state, exit, { exits: {} });
+    }).toThrow('Trying to submit incorrect exit');
+  });
+
+  test('non-existent utxo', () => {
+    const deposit = Tx.deposit(12, 500, ADDR_1, 0);
+    const outpoint = new Outpoint(deposit.hash(), 0);
+    const state = {
+      unspent: {},
+    };
+
+    const exit = Tx.exit(new Input(outpoint));
+    expect(() => {
+      checkExit(state, exit, makeExitMock(ADDR_1, '500', 0));
     }).toThrow('Trying to submit incorrect exit');
   });
 


### PR DESCRIPTION
`checkExit` used to fail for non-existing utxo (that's good), but because of `TypeError: Cannot read property \'address\' of undefined` (that's not good).

For example, here https://github.com/leapdao/leapdao-integ-tests/pull/8/files#diff-c545251c3884e9b6965f1ca3e4cbdcbaR42

This PR is to handle the situation properly