### PR TITLE
add --tendermintAddr option to set tendermint RPC host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV RPC_PORT "8645"
 ENV WS_ADDR "0.0.0.0"
 ENV WS_PORT "8646"
 ENV P2P_PORT "46691"
+ENV TENDERMINT_ADDR "0.0.0.0"
 # Either CONFIG_URL or NETWORK needs to be defined, CONFIG_URL takes precedence
 ENV CONFIG_URL "http://node1.testnet.leapdao.org:8645"
 # for presets/leap-NETWORK

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ async function run() {
     abciPort: cliArgs.abciPort,
     peers: config.peers,
     p2pPort: cliArgs.p2pPort,
+    tendermintAddr: cliArgs.tendermintAddr,
     tendermintPort: cliArgs.tendermintPort,
     createEmptyBlocks: false,
     logTendermint: log => {

--- a/lotion/index.js
+++ b/lotion/index.js
@@ -150,6 +150,8 @@ function Lotion(opts = {}) {
           opts.abciPort
         );
 
+        const { tendermintAddr } = opts;
+
         // initialize merk store
         const merkDb = level(join(lotionPath, 'merk'));
         const store = await merk(merkDb);
@@ -176,6 +178,7 @@ function Lotion(opts = {}) {
         try {
           tendermint = await Tendermint({
             lotionPath,
+            tendermintAddr,
             tendermintPort,
             abciPort,
             p2pPort,

--- a/lotion/lib/tendermint.js
+++ b/lotion/lib/tendermint.js
@@ -5,6 +5,7 @@ const tendermint = require('tendermint-node');
 
 module.exports = async ({
   lotionPath,
+  tendermintAddr,
   tendermintPort,
   abciPort,
   p2pPort,
@@ -48,7 +49,7 @@ module.exports = async ({
   );
 
   const opts = {
-    rpc: { laddr: `tcp://0.0.0.0:${tendermintPort}` },
+    rpc: { laddr: `tcp://${tendermintAddr}:${tendermintPort}` },
     p2p: { laddr: `tcp://0.0.0.0:${p2pPort}` },
     proxyApp: `tcp://127.0.0.1:${abciPort}`,
   };

--- a/src/utils/cliArgs.js
+++ b/src/utils/cliArgs.js
@@ -65,10 +65,17 @@ const options = [
     help: 'Port for p2p connection',
   },
   {
+    names: ['tendermintAddr'],
+    type: 'string',
+    env: 'TENDERMINT_ADDR',
+    default: '0.0.0.0',
+    help: 'Host for tendermint RPC connection',
+  },
+  {
     names: ['tendermintPort'],
     type: 'number',
     default: 26659,
-    help: 'Port for tendermint connection',
+    help: 'Port for tendermint RPC connection',
   },
   {
     names: ['abciPort'],


### PR DESCRIPTION
This will allow to run unsafe RPC without exposing it to the public: `--tendermintAddr 127.0.0.1`

Required for https://github.com/leapdao/leap-node/issues/185