### PR TITLE
fix: getColors forgets about old tokens

### DIFF
--- a/src/api/methods/getColors.js
+++ b/src/api/methods/getColors.js
@@ -15,10 +15,12 @@ const getColors = async (bridgeState, nft) => {
       await bridgeState.exitHandlerContract.methods.nftTokenCount().call()
     );
     if (tokenCount !== bridgeState.tokens.erc721.length) {
-      bridgeState.tokens.erc721 = await getTokensRange(
-        bridgeState,
-        NFT_COLOR_BASE + bridgeState.tokens.erc721.length,
-        NFT_COLOR_BASE + tokenCount
+      bridgeState.tokens.erc721 = bridgeState.tokens.erc721.concat(
+        await getTokensRange(
+          bridgeState,
+          NFT_COLOR_BASE + bridgeState.tokens.erc721.length,
+          NFT_COLOR_BASE + tokenCount
+        )
       );
     }
   } else {
@@ -26,10 +28,12 @@ const getColors = async (bridgeState, nft) => {
       await bridgeState.exitHandlerContract.methods.erc20TokenCount().call()
     );
     if (tokenCount !== bridgeState.tokens.erc20.length) {
-      bridgeState.tokens.erc20 = await getTokensRange(
-        bridgeState,
-        bridgeState.tokens.erc20.length,
-        tokenCount
+      bridgeState.tokens.erc20 = bridgeState.tokens.erc20.concat(
+        await getTokensRange(
+          bridgeState,
+          bridgeState.tokens.erc20.length,
+          tokenCount
+        )
       );
     }
   }


### PR DESCRIPTION
Fix for the second part of "DAI ruined the mainnet" problem.

Test for this fix: https://github.com/leapdao/integration-tests/pull/23


Related: https://github.com/leapdao/bridge-ui/pull/186, https://leapdao.slack.com/archives/CFQH2UH3Q/p1552316713000500