### PR TITLE
do not send activate and submitPeriod txs from readonly node

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ async function run() {
   const nodeConfig = Object.assign({}, cliArgs, { network: config });
 
   app.useTx(txHandler(bridgeState, nodeConfig));
-  app.useBlock(blockHandler(bridgeState, db, cliArgs.no_validators_updates));
+  app.useBlock(blockHandler(bridgeState, db, nodeConfig));
   app.usePeriod(periodHandler(bridgeState));
 
   app.listen(cliArgs.port).then(async params => {

--- a/src/block/index.js
+++ b/src/block/index.js
@@ -5,17 +5,17 @@ const updatePeriod = require('./updatePeriod');
 const updateValidators = require('./updateValidators');
 const updateEpoch = require('./updateEpoch');
 
-module.exports = (bridgeState, db, noValidatorsUpdates) => async (
+module.exports = (bridgeState, db, nodeConfig = {}) => async (
   state,
   chainInfo
 ) => {
   bridgeState.checkCallsCount = 0;
-  await updatePeriod(state, chainInfo, bridgeState);
+  await updatePeriod(state, chainInfo, bridgeState, nodeConfig);
   await addBlock(state, chainInfo, {
     bridgeState,
     db,
   });
-  if (!noValidatorsUpdates && state.slots.length > 0) {
+  if (!nodeConfig.no_validators_updates && state.slots.length > 0) {
     await updateValidators(state, chainInfo);
   }
 

--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -11,7 +11,7 @@ const activateSlot = require('../txHelpers/activateSlot');
 const { getAuctionedByAddr } = require('../utils');
 const { logPeriod } = require('../utils/debug');
 
-module.exports = async (state, chainInfo, bridgeState) => {
+module.exports = async (state, chainInfo, bridgeState, nodeConfig = {}) => {
   if (chainInfo.height % 32 === 0) {
     logPeriod('updatePeriod');
     try {
@@ -19,7 +19,8 @@ module.exports = async (state, chainInfo, bridgeState) => {
         bridgeState.currentPeriod,
         state.slots,
         chainInfo.height,
-        bridgeState
+        bridgeState,
+        nodeConfig
       );
     } catch (err) {
       logPeriod(err);
@@ -37,7 +38,7 @@ module.exports = async (state, chainInfo, bridgeState) => {
     )
       .filter(({ activationEpoch }) => activationEpoch - state.epoch.epoch >= 2)
       .map(({ id }) => id);
-    if (myAuctionedSlots.length > 0) {
+    if (myAuctionedSlots.length > 0 && !nodeConfig.readonly) {
       logPeriod('found some slots for activation', myAuctionedSlots);
       myAuctionedSlots.forEach(id => {
         const tx = activateSlot(id, bridgeState);

--- a/src/period/index.js
+++ b/src/period/index.js
@@ -8,7 +8,7 @@
 const submitPeriod = require('../txHelpers/submitPeriod');
 const { logPeriod } = require('../utils/debug');
 
-module.exports = bridgeState => async (rsp, chainInfo) => {
+module.exports = (bridgeState, nodeConfig = {}) => async (rsp, chainInfo) => {
   const height = chainInfo.height - 32;
   if (height === 0) {
     // genesis height doesn't need check
@@ -21,7 +21,8 @@ module.exports = bridgeState => async (rsp, chainInfo) => {
     bridgeState.previousPeriod,
     bridgeState.currentState.slots,
     height + bridgeState.checkCallsCount,
-    bridgeState
+    bridgeState,
+    nodeConfig
   );
 
   if (contractPeriod.timestamp === '0') {

--- a/src/txHelpers/submitPeriod.js
+++ b/src/txHelpers/submitPeriod.js
@@ -19,7 +19,13 @@ const logError = height => err => {
 };
 const eventDistance = 4 * 60 * 12; // about 12 hours on main-net
 
-module.exports = async (period, slots, height, bridgeState) => {
+module.exports = async (
+  period,
+  slots,
+  height,
+  bridgeState,
+  nodeConfig = {}
+) => {
   // query the contracts for submissions
   // to find the period roots to the merkle roots
   const parentHeight = await bridgeState.web3.eth.getBlockNumber();
@@ -52,6 +58,11 @@ module.exports = async (period, slots, height, bridgeState) => {
       .periods(currentPeriodRoot)
       .call();
     logPeriod('submittedPeriod', period.merkleRoot(), submittedPeriod);
+  }
+
+  if (nodeConfig.readonly) {
+    logPeriod('Readonly node. Skipping the rest of submitPeriod');
+    return submittedPeriod;
   }
 
   if (submittedPeriod.timestamp === '0') {


### PR DESCRIPTION
ensure readonly node is not submitting periods and activation transactions. It assumed that readonly node is accompanied by writeable node with the same validator key, which does all the hustle.

TODO:
- [ ] tests