### PR TITLE
don't submit period if no prev period root found

### DIFF
--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -155,6 +155,10 @@ module.exports = class BridgeState {
       MinGasPrice: ({ returnValues: event }) => {
         this.minGasPrices.push(Number(event.minGasPrice));
       },
+      Submission: ({ returnValues: event }) => {
+        this.lastBlocksRoot = event.blocksRoot;
+        this.lastPeriodRoot = event.periodRoot;
+      },
     });
 
     await handler(events);

--- a/src/txHelpers/submitPeriod.js
+++ b/src/txHelpers/submitPeriod.js
@@ -9,7 +9,6 @@ const {
   getSlotsByAddr,
   sendTransaction,
   getCurrentSlotId,
-  GENESIS,
 } = require('../utils');
 const { logPeriod } = require('../utils/debug');
 
@@ -72,11 +71,17 @@ module.exports = async (
     logPeriod('mySlots', currentSlotId, mySlots);
     if (currentSlot) {
       logPeriod('submitPeriod. Slot %d', currentSlot.id);
+      if (!prevPeriodRoot) {
+        logPeriod(
+          'submitPeriod. Not previous period root found. Skipping submission'
+        );
+        return submittedPeriod;
+      }
       const tx = sendTransaction(
         bridgeState.web3,
         bridgeState.operatorContract.methods.submitPeriod(
           currentSlot.id,
-          prevPeriodRoot || GENESIS,
+          prevPeriodRoot,
           period.merkleRoot()
         ),
         bridgeState.operatorContract.options.address,

--- a/src/txHelpers/submitPeriod.js
+++ b/src/txHelpers/submitPeriod.js
@@ -9,6 +9,7 @@ const {
   getSlotsByAddr,
   sendTransaction,
   getCurrentSlotId,
+  GENESIS,
 } = require('../utils');
 const { logPeriod } = require('../utils/debug');
 
@@ -16,7 +17,21 @@ const { logPeriod } = require('../utils/debug');
 const logError = height => err => {
   logPeriod('submitPeriod error: %s (height: %d)', err.message, height);
 };
-const eventDistance = 4 * 60 * 12; // about 12 hours on main-net
+
+const mySlotToSubmitFor = (slots, height, bridgeState) => {
+  const mySlots = getSlotsByAddr(slots, bridgeState.account.address);
+  const currentSlotId = getCurrentSlotId(slots, height);
+  logPeriod('mySlots', currentSlotId, mySlots);
+  return mySlots.find(slot => slot.id === currentSlotId);
+};
+
+const getPrevPeriodRoot = (period, bridgeState, height) => {
+  const { lastBlocksRoot, lastPeriodRoot } = bridgeState;
+
+  if (lastBlocksRoot === period.prevHash) return lastPeriodRoot; // found
+  if (height === 32) return GENESIS; // not found on 32 block = first period to be submitted
+  return null; // not found
+};
 
 module.exports = async (
   period,
@@ -25,73 +40,47 @@ module.exports = async (
   bridgeState,
   nodeConfig = {}
 ) => {
-  // query the contracts for submissions
-  // to find the period roots to the merkle roots
-  const parentHeight = await bridgeState.web3.eth.getBlockNumber();
-  const submissions = await bridgeState.operatorContract.getPastEvents(
-    'Submission',
-    {
-      filter: {
-        blocksRoot: [period.prevHash, period.merkleRoot()],
-      },
-      fromBlock: parentHeight - eventDistance,
-    }
-  );
+  const { lastBlocksRoot, lastPeriodRoot } = bridgeState;
   let submittedPeriod = { timestamp: '0' };
 
-  // if last period not submitted, only period.prevHash would find an event
-  // if current period submitted already, period.merkleRoot() would also match an event
-  let prevPeriodRoot;
-  let currentPeriodRoot;
-  for (let i = 0; i < submissions.length; i += 1) {
-    if (submissions[i].returnValues.blocksRoot === period.prevHash) {
-      prevPeriodRoot = submissions[i].returnValues.periodRoot;
-    }
-    if (submissions[i].returnValues.blocksRoot === period.merkleRoot()) {
-      currentPeriodRoot = submissions[i].returnValues.periodRoot;
-    }
-  }
-
-  if (currentPeriodRoot) {
+  if (lastBlocksRoot === period.merkleRoot()) {
     submittedPeriod = await bridgeState.bridgeContract.methods
-      .periods(currentPeriodRoot)
+      .periods(lastPeriodRoot)
       .call();
     logPeriod('submittedPeriod', period.merkleRoot(), submittedPeriod);
+    return submittedPeriod;
   }
+
+  const prevPeriodRoot = getPrevPeriodRoot(period, bridgeState, height);
 
   if (nodeConfig.readonly) {
     logPeriod('Readonly node. Skipping the rest of submitPeriod');
     return submittedPeriod;
   }
 
-  if (submittedPeriod.timestamp === '0') {
-    const mySlots = getSlotsByAddr(slots, bridgeState.account.address);
-    const currentSlotId = getCurrentSlotId(slots, height);
-    const currentSlot = mySlots.find(slot => slot.id === currentSlotId);
-    logPeriod('mySlots', currentSlotId, mySlots);
-    if (currentSlot) {
-      logPeriod('submitPeriod. Slot %d', currentSlot.id);
-      if (!prevPeriodRoot) {
-        logPeriod(
-          'submitPeriod. Not previous period root found. Skipping submission'
-        );
-        return submittedPeriod;
-      }
-      const tx = sendTransaction(
-        bridgeState.web3,
-        bridgeState.operatorContract.methods.submitPeriod(
-          currentSlot.id,
-          prevPeriodRoot,
-          period.merkleRoot()
-        ),
-        bridgeState.operatorContract.options.address,
-        bridgeState.account
-      ).catch(logError(height));
-
-      tx.then(receipt => {
-        logPeriod('submitPeriod tx', receipt);
-      });
+  const mySlotToSubmit = mySlotToSubmitFor(slots, height, bridgeState);
+  if (mySlotToSubmit) {
+    logPeriod('submitPeriod. Slot %d', mySlotToSubmit.id);
+    if (!prevPeriodRoot) {
+      logPeriod(
+        'submitPeriod. Not previous period root found. Skipping submission'
+      );
+      return submittedPeriod;
     }
+    const tx = sendTransaction(
+      bridgeState.web3,
+      bridgeState.operatorContract.methods.submitPeriod(
+        mySlotToSubmit.id,
+        prevPeriodRoot,
+        period.merkleRoot()
+      ),
+      bridgeState.operatorContract.options.address,
+      bridgeState.account
+    ).catch(logError(height));
+
+    tx.then(receipt => {
+      logPeriod('submitPeriod tx', receipt);
+    });
   }
 
   return submittedPeriod;

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -176,6 +176,6 @@ describe('submitPeriod', async () => {
     expect(period).toEqual({
       timestamp: '0',
     });
-    expect(submitCalled).toBe(true);
+    expect(submitCalled).toBe(false);
   });
 });

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -25,19 +25,6 @@ describe('submitPeriod', async () => {
       },
     };
 
-    const operatorContract = {
-      getPastEvents: async () => {
-        return [
-          {
-            returnValues: {
-              blocksRoot: '0x',
-              periodRoot: '0x',
-            },
-          },
-        ];
-      },
-    };
-
     const account = {
       address: ADDR,
     };
@@ -45,12 +32,12 @@ describe('submitPeriod', async () => {
     const period = await submitPeriod(
       {
         merkleRoot() {
-          return '0x';
+          return '0x1234';
         },
       },
       [],
       0,
-      { bridgeContract, web3, operatorContract, account }
+      { bridgeContract, web3, account, lastBlocksRoot: '0x1234' }
     );
     expect(period).toEqual({
       timestamp: '100',
@@ -76,16 +63,6 @@ describe('submitPeriod', async () => {
     const operatorContract = {
       options: {
         address: ADDR,
-      },
-      getPastEvents: async () => {
-        return [
-          {
-            returnValues: {
-              blocksRoot: '0x',
-              periodRoot: '0x',
-            },
-          },
-        ];
       },
       methods: {
         submitPeriod: () => {
@@ -137,16 +114,6 @@ describe('submitPeriod', async () => {
     const operatorContract = {
       options: {
         address: ADDR,
-      },
-      getPastEvents: async () => {
-        return [
-          {
-            returnValues: {
-              blocksRoot: '0x',
-              periodRoot: '0x',
-            },
-          },
-        ];
       },
       methods: {
         submitPeriod: () => {


### PR DESCRIPTION
First take. Addressing https://leapdao.slack.com/archives/CFKUNHHC7/p1552019049001600
resolves: https://github.com/leapdao/leap-node/issues/172

TODO:
- [x] don't submit GENESIS root hash if no prev root found
- [x] store period roots in bridgeState, don't read events in `submitPeriod`