### PR TITLE
Remote debugging / profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ To enable logs use `DEBUG` env variable (see: https://www.npmjs.com/package/debu
 
 Example: `DEBUG=tendermint,leap-node:tx leap-node`
 
+#### Debug via Blink Developer Tools / node-inspector
+
+Start node with `--inspect` and port `9999` for example:
+
+`$ node --inspect=9999 /path/to/leap-node <usual args>`
+
+You can connect to the debugger via `chrome://inspect` in the Chrom{ e, ium } browser,
+or with tools like [node-inspector](https://github.com/node-inspector/node-inspector).
+
+Connecting to Remote host using ssh:
+
+`$ ssh -vNL9999:127.0.0.1:9999 <user@remote host>...`
+
+Your local port `9999` forwards now to the remote host on address `127.0.0.1` and port `9999`.
+
 ### Available cli arguments
 
 - `no-validators-updates` — disabling validators set updates (default: false)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@ version: '3'
 
 services:
   leap-node:
+    entrypoint: node
+    command:
+      - --inspect=0.0.0.0:9999
+      - /opt/leap-node/bin.js
     restart: unless-stopped
     build:
       context: .
@@ -21,6 +25,8 @@ services:
       - "26659:26659"
       # p2p
       - "46691:46691"
+      # devtools-protocol
+      - "127.0.0.1:9999:9999"
     environment:
       - "DEBUG=${DEBUG}"
       - "NO_VALIDATORS_UPDATES=${NO_VALIDATORS_UPDATES}"

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ async function run() {
     return result;
   })();
 
-  const app = lotion({
+  global.app = lotion({
     initialState: {
       mempool: [],
       balances: {}, // stores account balances like this { [colorIndex]: { address1: 0, ... } }
@@ -81,21 +81,21 @@ async function run() {
     process.exit(0);
   }
 
-  const db = Db(app);
+  global.db = Db(app);
 
   const privKey = await readPrivKey(app, cliArgs);
 
-  const eventsRelay = new EventsRelay(
+  global.eventsRelay = new EventsRelay(
     config.eventsDelay,
     cliArgs.tendermintPort
   );
-  const bridgeState = new BridgeState(
+  global.bridgeState = new BridgeState(
     db,
     privKey,
     config,
     eventsRelay.relayBuffer
   );
-  const blockTicker = new BlockTicker(bridgeState.web3, [
+  global.blockTicker = new BlockTicker(bridgeState.web3, [
     bridgeState.onNewBlock,
   ]);
 

--- a/setup/cloud/leap.systemd.service
+++ b/setup/cloud/leap.systemd.service
@@ -9,7 +9,7 @@ User=ubuntu
 Group=ubuntu
 PermissionsStartOnly=true
 Environment="DEBUG=tendermint,leap-node*"
-ExecStart=/bin/sh -c 'exec /usr/local/bin/leap-node --p2pPort=46691 --rpcaddr=0.0.0.0 --rpcport=8645 --wsaddr=0.0.0.0 --wsport=8646 --config=/home/ubuntu/${network}.json >>/home/ubuntu/logs/leap-node.log 2>&1'
+ExecStart=/bin/sh -c 'exec node --inspect=9999 /usr/local/bin/leap-node --p2pPort=46691 --rpcaddr=0.0.0.0 --rpcport=8645 --wsaddr=0.0.0.0 --wsport=8646 --config=/home/ubuntu/${network}.json >>/home/ubuntu/logs/leap-node.log 2>&1'
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
 


### PR DESCRIPTION
- Enables the DevTools protocol on port 9999@localhost
- Readme example with ssh relay
- assign bridgeState and other useful things to `global`

Fixes #192