### PR TITLE
hotfix: gas price is not decimal

### DIFF
--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -85,7 +85,7 @@ module.exports = class BridgeState {
       this.web3,
       contracts,
       this.eventsBuffer,
-      genesisBlock
+      parseInt(genesisBlock, 10)
     );
     const blockNumber = await this.web3.eth.getBlockNumber();
     await this.eventsSubscription.init();

--- a/src/utils/getRootGasPrice.js
+++ b/src/utils/getRootGasPrice.js
@@ -26,7 +26,7 @@ module.exports = async function getRootGasPrice(web3, urgency = 'fast') {
   return axios
     .get(GAS_STATION_API)
     .then(response => {
-      return Math.min(MAX_GAS_PRICE, (response.data[urgency] / 10) * 10 ** 9);
+      return Math.min(MAX_GAS_PRICE, (response.data[urgency] * 10 ** 9) / 10);
     })
     .catch(e => {
       throw new Error('Gas Station error', e);

--- a/src/utils/getRootGasPrice.test.js
+++ b/src/utils/getRootGasPrice.test.js
@@ -13,7 +13,7 @@ axios.get.mockResolvedValue({
     block_time: 19.228571428571428,
     blockNum: 7269705,
     speed: 0.998286333650524,
-    safeLowWait: 22.6,
+    safeLowWait: 169.0,
     avgWait: 3.2,
     fastWait: 0.6,
     fastestWait: 0.6,
@@ -32,6 +32,11 @@ describe('getRootGasPrice', () => {
     test('reads specified gas price from gas station API', async () => {
       const result = await getRootGasPrice(web3, 'safeLow');
       expect(result).toBe(13400000000);
+    });
+
+    test('reads specified gas price from gas station API', async () => {
+      const result = await getRootGasPrice(web3, 'safeLowWait');
+      expect(result).toBe(16900000000);
     });
 
     test('caps gas price to 200 gwei', async () => {


### PR DESCRIPTION
Appears on mainnet when ethGasStation returns fast estimate of 16.9 gwei

Error: [number-to-bn] while converting number 16899999999.999998 to BN.js instance

https://leapdao.slack.com/archives/CFQH2UH3Q/p1558088707002300