### PR TITLE
fix: rethrow error from EVM

### DIFF
--- a/src/tx/applyTx/checkSpendCond.js
+++ b/src/tx/applyTx/checkSpendCond.js
@@ -407,6 +407,7 @@ module.exports = async (state, tx, bridgeState, nodeConfig = {}) => {
     });
   } catch (err) {
     console.log(err);
+    throw err;
   }
 
   const logOuts = [];


### PR DESCRIPTION
make check spend condition fail if tx failed preserving [old behavior](https://github.com/leapdao/leap-node/pull/291/files#diff-b4471cf36ae8847d81e79bc7b9160f44R405).

Actually replacing `{ error: 'TypeError: Cannot read property \'vm\' of undefined' }` with `VmError { error: 'revert', errorType: 'VmError' }` 😂 

Details: https://leapdao.slack.com/archives/CFKUNHHC7/p1563400681015000