### PR TITLE
feat: index transactions by utxo they spend

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jayson": "^2.0.6",
     "jsbi-utils": "^1.0.0",
     "jsondiffpatch": "^0.2.5",
-    "leap-core": "^0.34.1-beta.0",
+    "leap-core": "^0.34.1",
     "level": "^4.0.0",
     "lodash": "^4.17.13",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jayson": "^2.0.6",
     "jsbi-utils": "^1.0.0",
     "jsondiffpatch": "^0.2.5",
-    "leap-core": "0.34.0",
+    "leap-core": "^0.34.1-beta.0",
     "level": "^4.0.0",
     "lodash": "^4.17.13",
     "lodash.get": "^4.4.2",

--- a/src/api/createDb.js
+++ b/src/api/createDb.js
@@ -12,8 +12,9 @@ const createDb = levelDb => {
   const storeBlock = async block => {
     const dbOpsBatch = levelDb.batch();
     block.txList.forEach((tx, txPos) => {
+      const txKey = `tx!${tx.hash()}`;
       dbOpsBatch.put(
-        `tx!${tx.hash()}`,
+        txKey,
         JSON.stringify({
           txData: tx.toJSON(),
           blockHash: block.hash(),
@@ -21,6 +22,13 @@ const createDb = levelDb => {
           txPos,
         })
       );
+
+      const outputsSpentByTx = tx.inputs
+        .filter(i => i.isSpend())
+        .map(i => `${i.prevout.txid()}:${i.prevout.index}`);
+
+      // create 'utxoId → tx' index
+      outputsSpentByTx.forEach(utxo => dbOpsBatch.put(`out!${utxo}`, txKey));
     });
 
     dbOpsBatch.put(
@@ -47,7 +55,11 @@ const createDb = levelDb => {
       .then(jsonStr => {
         // hash, not object
         if (jsonStr.indexOf('0x') === 0) return jsonStr;
-        return JSON.parse(jsonStr);
+        try {
+          return JSON.parse(jsonStr);
+        } catch (e) {
+          return jsonStr;
+        }
       })
       .catch(e => {
         if (e.type === 'NotFoundError') return null;
@@ -56,17 +68,27 @@ const createDb = levelDb => {
   };
 
   /*
-   * Returns block data for given hash
+   * Returns block data for a given hash
    */
   const getBlock = hash => {
     return getNullable(`block!${hash}`);
   };
 
   /*
-   * Returns tx data for given hash
+   * Returns tx data for a given hash
    */
   const getTransaction = hash => {
     return getNullable(`tx!${hash}`);
+  };
+
+  /*
+   * Returns tx data for tx spending a given utxo
+   */
+  const getTransactionByPrevOut = outpoint => {
+    return getNullable(`out!${outpoint}`).then(txKey => {
+      if (!txKey) return null;
+      return getNullable(txKey);
+    });
   };
 
   /*
@@ -88,6 +110,7 @@ const createDb = levelDb => {
     storeBlock,
     getBlock,
     getTransaction,
+    getTransactionByPrevOut,
     getChainState,
     storeChainState,
   };

--- a/src/api/createDb.js
+++ b/src/api/createDb.js
@@ -23,12 +23,11 @@ const createDb = levelDb => {
         })
       );
 
-      const outputsSpentByTx = tx.inputs
-        .filter(i => i.isSpend())
-        .map(i => `${i.prevout.txid()}:${i.prevout.index}`);
-
       // create 'utxoId → tx' index
-      outputsSpentByTx.forEach(utxo => dbOpsBatch.put(`out!${utxo}`, txKey));
+      tx.inputs
+        .filter(i => i.isSpend())
+        .map(i => `${i.prevout.txid()}:${i.prevout.index}`)
+        .forEach(utxo => dbOpsBatch.put(`out!${utxo}`, txKey));
     });
 
     dbOpsBatch.put(

--- a/src/api/methods/getTransactionByPrevOut.js
+++ b/src/api/methods/getTransactionByPrevOut.js
@@ -1,0 +1,10 @@
+const { Tx } = require('leap-core');
+const txResponse = require('./txResponse');
+
+module.exports = async (db, utxoId) => {
+  const txDoc = await db.getTransactionByPrevOut(utxoId);
+  if (!txDoc) return null; // return null as Infura does
+
+  const { txData, blockHash, height, txPos } = txDoc;
+  return await txResponse(db, Tx.fromJSON(txData), blockHash, height, txPos); // eslint-disable-line no-return-await
+};

--- a/src/api/methods/getTransactionByPrevOut.test.js
+++ b/src/api/methods/getTransactionByPrevOut.test.js
@@ -1,0 +1,58 @@
+const { Tx, Input, Outpoint, Output } = require('leap-core');
+const txResponse = require('./txResponse');
+const getTransactionByPrevOut = require('./getTransactionByPrevOut');
+
+const PRIV1 =
+  '0x9b63fe8147edb8d251a6a66fd18c0ed73873da9fff3f08ea202e1c0a8ead7311';
+const A1 = '0xB8205608d54cb81f44F263bE086027D8610F3C94';
+
+describe('getTransactionByPrevOut', () => {
+  test('UTXO is not spent or non existing', async () => {
+    const db = {
+      async getTransactionByPrevOut() {
+        return null;
+      },
+    };
+
+    expect(await getTransactionByPrevOut(db, '0x00')).toBe(null);
+  });
+
+  test('Existent tx', async () => {
+    const out1 = new Outpoint(
+      '0x7777777777777777777777777777777777777777777777777777777777777777',
+      0
+    );
+
+    const out2 = new Outpoint(
+      '0x6666666666666666666666666666666666666666666666666666666666666666',
+      1
+    );
+    const tx = Tx.transfer(
+      [new Input(out1), new Input(out2)],
+      [new Output(100, A1, 0)]
+    ).signAll(PRIV1);
+
+    const data = {
+      txData: tx.toJSON(),
+      blockHash: '0x00',
+      height: 2,
+      txPos: 0,
+    };
+    const utxoId =
+      '0x6666666666666666666666666666666666666666666666666666666666666666:1';
+    const db = {
+      async getTransactionByPrevOut(prevOut) {
+        if (prevOut === utxoId) {
+          return data;
+        }
+        return null;
+      },
+      async getTransaction() {
+        return data;
+      },
+    };
+
+    const response = await getTransactionByPrevOut(db, utxoId);
+    expect(response).toEqual(await txResponse(db, tx, '0x00', 2, 0));
+  });
+});

--- a/src/api/methods/getUnsignedTransferTx.test.js
+++ b/src/api/methods/getUnsignedTransferTx.test.js
@@ -1,5 +1,4 @@
 const { Tx, Input, Outpoint, Output } = require('leap-core');
-const { bi } = require('jsbi-utils');
 const { EMPTY_ADDRESS } = require('../../utils/constants');
 
 const getUnsignedTransferTx = require('./getUnsignedTransferTx');
@@ -110,7 +109,7 @@ describe('getUnsignedTransferTx', () => {
       ],
       to: A2.toLowerCase(),
       from: EMPTY_ADDRESS,
-      value: bi('200'),
+      value: '200',
       color: 0,
     };
 
@@ -151,7 +150,7 @@ describe('getUnsignedTransferTx', () => {
       ],
       to: A2.toLowerCase(),
       from: EMPTY_ADDRESS,
-      value: bi('260'),
+      value: '260',
       color: 1,
     };
 

--- a/src/api/methods/index.js
+++ b/src/api/methods/index.js
@@ -43,6 +43,10 @@ module.exports = (bridgeState, db, app, tendermintPort) => {
     plasma_getColors: require('./getColors').bind(null, bridgeState),
     plasma_status: require('./getNodeStatus').bind(null, bridgeState, app),
     plasma_getConfig: require('./getConfig').bind(null, bridgeState, app),
+    plasma_getTransactionByPrevOut: require('./getTransactionByPrevOut').bind(
+      null,
+      db
+    ),
     validator_getAddress: require('./getAddress').bind(null, bridgeState, app),
     checkSpendingCondition: require('./checkSpendingCondition.js').bind(
       null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,10 +4129,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@^0.34.1-beta.0:
-  version "0.34.1-beta.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.34.1-beta.0.tgz#8900478e01f77a341b3921b88727bc4c6cbd86d0"
-  integrity sha512-Ute6TYfcqr2M17jff8mU9RpBbiLMyVWZFAhwSq3u+FyusfeNsj3AR82wFpdFS2MPwD9gzp148mvG9zgpX18hVw==
+leap-core@^0.34.1:
+  version "0.34.1"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.34.1.tgz#d3ac8cd5d30aee5a6651096ce425274c635e0073"
+  integrity sha512-ARgwZGbMLSTDoDMtOQPT9e6CrsaRWAJ2KfzQOzhLHfFn++Z7NPrAGorncUpN5/Cj+SiSSR1CUXERupN4Z1cOlw==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4129,10 +4129,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@0.34.0:
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.34.0.tgz#f1a15120b9f9dae458b7530691bfe39ea24f09cd"
-  integrity sha512-8lxzidBshB6hht8filANy464G69FWSYgStHG2CLPWqjj/ZgK730fxlanjMSz/L9BMXzjiYREI55Fi/f5liy3Ow==
+leap-core@^0.34.1-beta.0:
+  version "0.34.1-beta.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.34.1-beta.0.tgz#8900478e01f77a341b3921b88727bc4c6cbd86d0"
+  integrity sha512-Ute6TYfcqr2M17jff8mU9RpBbiLMyVWZFAhwSq3u+FyusfeNsj3AR82wFpdFS2MPwD9gzp148mvG9zgpX18hVw==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"


### PR DESCRIPTION
Adds `plasma_getTransactionByPrevOut` RPC call. See usage below

Requires: https://github.com/leapdao/leap-core/pull/131

Resolves #283 

Possible test scenario:
1. Start a local leap network. [How](https://github.com/leapdao/integration-tests#start-local-environment-for-development)
2. Copy the funded priv key from local network console.
3. Send transfer tx with machine gun. [How](https://github.com/leapdao/leap-guardian#machine-gun)
Receipt:
```
{ to: '0xCED6Cec7891276E58d9434426831709fcBdD0C49',
  from: '0xCED6Cec7891276E58d9434426831709fcBdD0C49',
  contractAddress: null,
  transactionIndex: 0,
  gasUsed: BigNumber { _hex: '0x0' },
  logsBloom: '0x',
  blockHash:
   '0x6c5114be8ee90289fe40e0e733c36ccf36c0b9fedc7eb3f0aba25f688497b050',
  transactionHash:
   '0x95cdf222b4b5b6713c7deaac64d85c5216ec5dab32ab18598c428959b67e4728',
  logs: [],
  blockNumber: 7,
  confirmations: 1,
  cumulativeGasUsed: BigNumber { _hex: '0x0' },
  status: 1,
  byzantium: true }
```
4. Check that utxo `0x95cdf222b4b5b6713c7deaac64d85c5216ec5dab32ab18598c428959b67e4728:0` is not spent:

Request
```
curl -X POST \
  http://localhost:7000/ \
  -H 'Content-Type: application/json' \
  -d '{
  "method": "plasma_getTransactionByPrevOut",
  "params": ["0x95cdf222b4b5b6713c7deaac64d85c5216ec5dab32ab18598c428959b67e4728:0"],
  "id": 1,
  "jsonrpc": "2.0"
}'
```

Response: null data

5. Fire one more machine gun shot with same params. It will spend the first UTXO.
6. Check that utxo `0x95cdf222b4b5b6713c7deaac64d85c5216ec5dab32ab18598c428959b67e4728:0` is spent now. The `plasma_getTransactionByPrevOut` RPC will return the last tx by machine gun.


