### PR TITLE
feat(config): allow to specify data folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Your local port `9999` forwards now to the remote host on address `127.0.0.1` an
 - `p2pPort` — port for p2p connection (default: random)
 - `config` — path to config file or node's JSON RPC url (eg https://testnet-2.leapdao.org)
 - `version` — print version of the node
+- `dataPath` — path to folder with network data (default: `~/.lotion/networks/<network>—<networkdId>`)
 
 ### Config file options
   "bridgeAddr": "0x7b8342412883f4b34f335d4e1391ec190eb887ca",

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ async function run() {
     },
     unsafeRpc: cliArgs.unsafeRpc,
     readonlyValidator: cliArgs.readonly,
+    dataPath: cliArgs.dataPath,
   });
 
   if (cliArgs.fresh) {

--- a/lotion/index.js
+++ b/lotion/index.js
@@ -68,7 +68,7 @@ function Lotion(opts = {}) {
       devMode,
       genesis
     );
-  lotionPath = join(LOTION_HOME, 'networks', networkId);
+  lotionPath = opts.dataPath || join(LOTION_HOME, 'networks', networkId);
 
   if (devMode) {
     lotionPath += Math.floor(Math.random() * 1e9);
@@ -126,7 +126,7 @@ function Lotion(opts = {}) {
       // TODO: rename "post listen", there's probably a more descriptive name.
       postListenMiddleware.push(postListener);
     },
-    listen: (store) => {
+    listen: store => {
       return new Promise(async resolve => {
         // set up abci server, then tendermint node
         const { tendermintPort, abciPort, p2pPort } = await getPorts(

--- a/src/utils/cliArgs.js
+++ b/src/utils/cliArgs.js
@@ -121,6 +121,12 @@ const options = [
     env: 'UNSAFE_RPC',
     help: 'Run unsafe Tendermint RPC',
   },
+  {
+    names: ['dataPath'],
+    type: 'string',
+    env: 'DATA_PATH',
+    help: 'Path to lotion folder',
+  },
 ];
 
 const parser = dashdash.createParser({ options });


### PR DESCRIPTION
Added new optional CLI argument: `--dataPath` to specify where to store network data.

Maybe useful to run two nodes on the same machine without `devMode` and Docker.