### PR TITLE
feat: submit period with CAS once got 2/3 of the votes.

### DIFF
--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -54,6 +54,7 @@ module.exports = async (
         sender
       );
     } catch (err) {
+      /* istanbul ignore next */
       logPeriod(`period vote: ${err}`);
     }
     bridgeState.previousPeriod = bridgeState.currentPeriod;

--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -23,7 +23,7 @@ module.exports = async (
   if (bridgeState.previousPeriod) {
     const previousPeriodRoot = bridgeState.previousPeriod.merkleRoot();
     const { result } = checkEnoughVotes(previousPeriodRoot, state);
-    if (result && !bridgeState.periodsInFlight[previousPeriodRoot]) {
+    if (result && !bridgeState.submittedPeriods[previousPeriodRoot]) {
       logPeriod(`Enough votes to submit period: ${previousPeriodRoot}`);
       try {
         await submitPeriod(
@@ -32,6 +32,7 @@ module.exports = async (
           bridgeState.periodHeights[previousPeriodRoot],
           bridgeState
         );
+        bridgeState.submittedPeriods[previousPeriodRoot] = true;
       } catch (err) {
         /* istanbul ignore next */
         logPeriod(`submit period: ${err}`);
@@ -42,8 +43,8 @@ module.exports = async (
   if (chainInfo.height % 32 === 0) {
     logPeriod('updatePeriod');
     try {
-      bridgeState.periodHeights[bridgeState.currentPeriod.merkleRoot()] =
-        chainInfo.height - 1;
+      bridgeState.periodHeights[bridgeState.currentPeriod.merkleRoot()] = 
+        chainInfo.height;
       // will be executed by all the nodes, but the actual period vote tx will be
       // submitted by validators only
       await submitPeriodVote(

--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -53,14 +53,6 @@ module.exports = async (
         bridgeState,
         sender
       );
-
-      await submitPeriod(
-        bridgeState.currentPeriod,
-        state.slots,
-        chainInfo.height,
-        bridgeState,
-        nodeConfig
-      );
     } catch (err) {
       logPeriod(`period vote: ${err}`);
     }

--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -29,7 +29,7 @@ module.exports = async (
         await submitPeriod(
           bridgeState.previousPeriod,
           state.slots,
-          bridgeState.blockHeight,
+          bridgeState.periodHeights[previousPeriodRoot],
           bridgeState
         );
       } catch (err) {

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -116,7 +116,7 @@ describe('updatePeriod', () => {
       await updatePeriod(
         {
           periodVotes: { 
-            [NON_EXISTENT_PERIOD.merkleRoot()]: [] // no votes
+            [NON_EXISTENT_PERIOD.merkleRoot()]: [0]
           },
           slots: ['0x1'], // one slot
         },

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -85,7 +85,7 @@ describe('updatePeriod', () => {
       expect(submitPeriod).toBeCalledWith(NON_EXISTENT_PERIOD, ['0x1'], 32, bridgeState);
     });
 
-    test('do nothing period if not enough period votes and period pending', async () => {
+    test('do nothing if not enough period votes and period pending', async () => {
       const bridgeState = {
         previousPeriod: NON_EXISTENT_PERIOD,
         submittedPeriods: {},

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -85,7 +85,7 @@ describe('updatePeriod', () => {
       expect(submitPeriod).toBeCalledWith(NON_EXISTENT_PERIOD, ['0x1'], 32, bridgeState);
     });
 
-    test('do nothing if not enough period votes and period pending', async () => {
+    test('do nothing if not enough period votes', async () => {
       const bridgeState = {
         previousPeriod: NON_EXISTENT_PERIOD,
         submittedPeriods: {},
@@ -97,26 +97,6 @@ describe('updatePeriod', () => {
         {
           periodVotes: { 
             [NON_EXISTENT_PERIOD.merkleRoot()]: [] // no votes
-          },
-          slots: ['0x1'], // one slot
-        },
-        { height: 34 },
-        bridgeState
-      );
-  
-      expect(submitPeriod).not.toBeCalled();
-    });
-
-    test('do nothing if no period pending', async () => {
-      const bridgeState = {
-        previousPeriod: NON_EXISTENT_PERIOD,
-        submittedPeriods: {},
-        periodHeights: {}
-      };
-      await updatePeriod(
-        {
-          periodVotes: { 
-            [NON_EXISTENT_PERIOD.merkleRoot()]: [0]
           },
           slots: ['0x1'], // one slot
         },

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -107,13 +107,11 @@ describe('updatePeriod', () => {
       expect(submitPeriod).not.toBeCalled();
     });
 
-    test('do nothing period if no period pending', async () => {
+    test('do nothing if no period pending', async () => {
       const bridgeState = {
         previousPeriod: NON_EXISTENT_PERIOD,
         submittedPeriods: {},
-        periodHeights: {
-          [NON_EXISTENT_PERIOD.merkleRoot()]: 32
-        }
+        periodHeights: {}
       };
       await updatePeriod(
         {

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -1,7 +1,12 @@
 const updatePeriod = require('./updatePeriod');
 
-jest.mock('../txHelpers/submitPeriod');
 jest.mock('../utils/sendTransaction');
+
+jest.mock('../period/submitPeriodVote', () => jest.fn());
+const submitPeriodVote = jest.requireMock('../period/submitPeriodVote');
+
+jest.mock('../txHelpers/submitPeriod', () => jest.fn());
+const submitPeriod = jest.requireMock('../txHelpers/submitPeriod');
 
 const ADDR = '0x4436373705394267350db2c06613990d34621d69';
 const ADDR_2 = '0x4436373705394267350db2c06613990d34621d61';
@@ -17,35 +22,136 @@ describe('updatePeriod', () => {
   test('start new period each 32 blocks', async () => {
     const bridgeState = {
       currentPeriod: NON_EXISTENT_PERIOD,
+      periodHeights: {},
+    };
+    const state = {
+      slots: [],
     };
     await updatePeriod(
-      {
-        slots: [],
-      },
+      state,
       { height: 32 },
-      bridgeState
+      bridgeState,
+      {},
+      ADDR
     );
 
     expect(bridgeState.currentPeriod.prevHash).toBe(
       NON_EXISTENT_PERIOD.merkleRoot()
     );
     expect(bridgeState.previousPeriod).toBe(NON_EXISTENT_PERIOD);
+    expect(bridgeState.periodHeights[NON_EXISTENT_PERIOD.merkleRoot()]).toBe(32);
+    expect(submitPeriod).toBeCalledWith(NON_EXISTENT_PERIOD, [], 32, bridgeState, {});
+    expect(submitPeriodVote).toBeCalledWith(NON_EXISTENT_PERIOD, state, bridgeState, ADDR);
   });
 
-  test('do nothing at the height % 32 !== 0 || height % 32 !== 16', async () => {
-    const bridgeState = {
-      currentPeriod: NON_EXISTENT_PERIOD,
-    };
-    await updatePeriod(
-      {
-        slots: [],
-      },
-      { height: 15 },
-      bridgeState
-    );
+  describe('at the height % 32 !== 0 and height % 32 !== 16', () => {
 
-    expect(bridgeState.currentPeriod).toBe(NON_EXISTENT_PERIOD);
-    expect(bridgeState.previousPeriod).toBe(undefined);
+    test('do nothing if not enough period votes or no period yet', async () => {
+      const bridgeState = {
+        currentPeriod: NON_EXISTENT_PERIOD,
+        submittedPeriods: {},
+      };
+      await updatePeriod(
+        {
+          slots: [],
+        },
+        { height: 15 },
+        bridgeState
+      );
+  
+      expect(bridgeState.currentPeriod).toBe(NON_EXISTENT_PERIOD);
+      expect(bridgeState.previousPeriod).toBe(undefined);  
+    });
+
+    test('submit period if enough period votes and period pending', async () => {
+      const bridgeState = {
+        previousPeriod: NON_EXISTENT_PERIOD,
+        submittedPeriods: {},
+        periodHeights: {
+          [NON_EXISTENT_PERIOD.merkleRoot()]: 32
+        }
+      };
+      await updatePeriod(
+        {
+          periodVotes: { 
+            [NON_EXISTENT_PERIOD.merkleRoot()]: [0] // one vote
+          },
+          slots: ['0x1'], // one slot
+        },
+        { height: 34 },
+        bridgeState
+      );
+  
+      expect(submitPeriod).toBeCalledWith(NON_EXISTENT_PERIOD, ['0x1'], 32, bridgeState);
+    });
+
+    test('do nothing period if not enough period votes and period pending', async () => {
+      const bridgeState = {
+        previousPeriod: NON_EXISTENT_PERIOD,
+        submittedPeriods: {},
+        periodHeights: {
+          [NON_EXISTENT_PERIOD.merkleRoot()]: 32
+        }
+      };
+      await updatePeriod(
+        {
+          periodVotes: { 
+            [NON_EXISTENT_PERIOD.merkleRoot()]: [] // no votes
+          },
+          slots: ['0x1'], // one slot
+        },
+        { height: 34 },
+        bridgeState
+      );
+  
+      expect(submitPeriod).not.toBeCalled();
+    });
+
+    test('do nothing period if no period pending', async () => {
+      const bridgeState = {
+        previousPeriod: NON_EXISTENT_PERIOD,
+        submittedPeriods: {},
+        periodHeights: {
+          [NON_EXISTENT_PERIOD.merkleRoot()]: 32
+        }
+      };
+      await updatePeriod(
+        {
+          periodVotes: { 
+            [NON_EXISTENT_PERIOD.merkleRoot()]: [] // no votes
+          },
+          slots: ['0x1'], // one slot
+        },
+        { height: 34 },
+        bridgeState
+      );
+  
+      expect(submitPeriod).not.toBeCalled();
+    });
+
+    test('do nothing period if period already submitted', async () => {
+      const bridgeState = {
+        previousPeriod: NON_EXISTENT_PERIOD,
+        submittedPeriods: {
+          [NON_EXISTENT_PERIOD.merkleRoot()]: true
+        },
+        periodHeights: {
+          [NON_EXISTENT_PERIOD.merkleRoot()]: 32
+        }
+      };
+      await updatePeriod(
+        {
+          periodVotes: { 
+            [NON_EXISTENT_PERIOD.merkleRoot()]: [] // no votes
+          },
+          slots: ['0x1'], // one slot
+        },
+        { height: 34 },
+        bridgeState
+      );
+  
+      expect(submitPeriod).not.toBeCalled();
+    });
   });
 
   test('activate own auctioned slots at height % 32 === 16', async () => {

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -40,7 +40,7 @@ describe('updatePeriod', () => {
     );
     expect(bridgeState.previousPeriod).toBe(NON_EXISTENT_PERIOD);
     expect(bridgeState.periodHeights[NON_EXISTENT_PERIOD.merkleRoot()]).toBe(32);
-    expect(submitPeriod).toBeCalledWith(NON_EXISTENT_PERIOD, [], 32, bridgeState, {});
+    expect(submitPeriod).not.toBeCalled();
     expect(submitPeriodVote).toBeCalledWith(NON_EXISTENT_PERIOD, state, bridgeState, ADDR);
   });
 

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -140,7 +140,7 @@ module.exports = class BridgeState {
       Submission: ({ returnValues: event }) => {
         this.lastBlocksRoot = event.blocksRoot;
         this.lastPeriodRoot = event.periodRoot;
-        const blockHeight = this.periodHeights[this.lastBlocksRoot];
+        const blockHeight = this.periodHeights[this.lastBlocksRoot] - 1;
         const [periodStart] = Period.periodBlockRange(blockHeight);
         this.submissions.push({
           periodStart,

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -144,7 +144,7 @@ module.exports = class BridgeState {
         const [periodStart] = Period.periodBlockRange(blockHeight);
         this.submissions.push({
           periodStart,
-          casBitmap: event.casRoot,
+          casBitmap: event.casBitmap,
           slotId: event.slotId,
           validatorAddress: event.owner,
         });

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -79,6 +79,7 @@ module.exports = class BridgeState {
     this.logsCache = {};
     this.submissions = [];
     this.periodHeights = {};
+    this.periodsInFlight = {};
 
     this.handleEvents = handleEvents({
       NewDeposit: ({ returnValues: event }) => {

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -79,7 +79,7 @@ module.exports = class BridgeState {
     this.logsCache = {};
     this.submissions = [];
     this.periodHeights = {};
-    this.periodsInFlight = {};
+    this.submittedPeriods = {};
 
     this.handleEvents = handleEvents({
       NewDeposit: ({ returnValues: event }) => {
@@ -140,6 +140,7 @@ module.exports = class BridgeState {
       Submission: ({ returnValues: event }) => {
         this.lastBlocksRoot = event.blocksRoot;
         this.lastPeriodRoot = event.periodRoot;
+        this.submittedPeriods[this.lastBlocksRoot] = true;
         const blockHeight = this.periodHeights[this.lastBlocksRoot] - 1;
         const [periodStart] = Period.periodBlockRange(blockHeight);
         this.submissions.push({

--- a/src/period/utils/checkEnoughVotes.js
+++ b/src/period/utils/checkEnoughVotes.js
@@ -14,7 +14,8 @@
  * - `needed` is a minimum number of votes needed for consensus
  */
 module.exports = (periodRoot, state) => {
-  const { periodVotes, slots } = state;
+  const periodVotes = state.periodVotes || {};
+  const slots = state.slots || [];
 
   const votes = (periodVotes[periodRoot] || []).length;
   const needed = Math.floor((slots.length * 2) / 3) + 1;

--- a/src/txHelpers/submitPeriod.js
+++ b/src/txHelpers/submitPeriod.js
@@ -110,7 +110,8 @@ module.exports = async (
       ),
       bridgeState.operatorContract.options.address,
       bridgeState.account
-    ).catch(() => {
+    )
+    .catch(/* istanbul ignore next */ () => { 
       delete inFlight[periodRoot];
       logError(height);
     });

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -28,6 +28,7 @@ const bridgeStateMock = attrs => ({
   currentState: {
     periodVotes: {},
   },
+  periodsInFlight: {},
   ...attrs,
 });
 

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -290,6 +290,13 @@ describe('submitPeriod', () => {
     });
 
     test('got enough votes: 3/4', async () => {
+      const slots = [
+        { signerAddr: ADDR, id: 0 },
+        { signerAddr: ADDR_1, id: 1 },
+        { signerAddr: ADDR_1, id: 2 },
+        { signerAddr: ADDR_1, id: 3 },
+      ];
+
       const bridgeState = bridgeStateMock({
         bridgeContract: bridgeContractMock({
           returnPeriod: { timestamp: '0' },
@@ -301,23 +308,13 @@ describe('submitPeriod', () => {
           periodVotes: {
             [period.merkleRoot()]: [0, 2, 3],
           },
-          slots: [
-            { signerAddr: ADDR, id: 0 },
-            { signerAddr: ADDR_1, id: 1 },
-            { signerAddr: ADDR_1, id: 2 },
-            { signerAddr: ADDR_1, id: 3 },
-          ],
+          slots,
         },
       });
 
       const submittedPeriod = await submitPeriod(
         period,
-        [
-          { signerAddr: ADDR, id: 0 },
-          { signerAddr: ADDR_1, id: 1 },
-          { signerAddr: ADDR_1, id: 2 },
-          { signerAddr: ADDR_1, id: 3 },
-        ],
+        slots,
         0,
         bridgeState,
         {}

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -6,6 +6,7 @@ jest.mock('../utils/sendTransaction');
 const ADDR = '0xb8205608d54cb81f44f263be086027d8610f3c94';
 const PRIV =
   '0x9b63fe8147edb8d251a6a66fd18c0ed73873da9fff3f08ea202e1c0a8ead7311';
+const ADDR_1 = '0xd56f7dfcd2baffbc1d885f0266b21c7f2912020c';
 
 const web3 = {};
 
@@ -24,6 +25,9 @@ const bridgeStateMock = attrs => ({
     address: ADDR,
     privateKey: PRIV,
   },
+  currentState: {
+    periodVotes: {},
+  },
   ...attrs,
 });
 
@@ -34,7 +38,7 @@ const operatorContractMock = () => ({
     address: ADDR,
   },
   methods: {
-    submitPeriod: submitPeriodWithCas,
+    submitPeriodWithCas,
   },
 });
 
@@ -94,6 +98,12 @@ describe('submitPeriod', () => {
       operatorContract: operatorContractMock(),
       lastBlocksRoot: period.prevHash,
       lastPeriodRoot: '0x1337',
+      currentState: {
+        periodVotes: {
+          [PERIOD_ROOT]: [0],
+        },
+        slots: [{ signerAddr: ADDR, id: 0 }],
+      },
     });
 
     const submittedPeriod = await submitPeriod(
@@ -107,7 +117,12 @@ describe('submitPeriod', () => {
     expect(submittedPeriod).toEqual({
       timestamp: '0',
     });
-    expect(submitPeriodWithCas).toBeCalledWith(0, '0x1337', PERIOD_ROOT);
+    expect(submitPeriodWithCas).toBeCalledWith(
+      0,
+      '0x1337',
+      PERIOD_ROOT,
+      '0x8000000000000000000000000000000000000000000000000000000000000000'
+    );
   });
 
   test('not submitted, own slot, first period', async () => {
@@ -116,6 +131,12 @@ describe('submitPeriod', () => {
         returnPeriod: { timestamp: '0' },
       }),
       operatorContract: operatorContractMock(),
+      currentState: {
+        periodVotes: {
+          [PERIOD_ROOT]: [0],
+        },
+        slots: [{ signerAddr: ADDR, id: 0 }],
+      },
     });
 
     const submittedPeriod = await submitPeriod(
@@ -129,7 +150,12 @@ describe('submitPeriod', () => {
     expect(submittedPeriod).toEqual({
       timestamp: '0',
     });
-    expect(submitPeriodWithCas).toBeCalledWith(0, GENESIS, PERIOD_ROOT);
+    expect(submitPeriodWithCas).toBeCalledWith(
+      0,
+      GENESIS,
+      PERIOD_ROOT,
+      '0x8000000000000000000000000000000000000000000000000000000000000000'
+    );
   });
 
   test('submitted, own slot, always try to submit for lastPeriodRoot', async () => {
@@ -140,6 +166,12 @@ describe('submitPeriod', () => {
       operatorContract: operatorContractMock(),
       lastBlocksRoot: '0x9999', // doesn't match period.prevHash
       lastPeriodRoot: '0x1337',
+      currentState: {
+        periodVotes: {
+          [PERIOD_ROOT]: [0],
+        },
+        slots: [{ signerAddr: ADDR, id: 0 }],
+      },
     });
 
     const submittedPeriod = await submitPeriod(
@@ -164,6 +196,12 @@ describe('submitPeriod', () => {
       operatorContract: operatorContractMock(),
       lastBlocksRoot: period.prevHash,
       lastPeriodRoot: '0x1337',
+      currentState: {
+        periodVotes: {
+          [PERIOD_ROOT]: [0],
+        },
+        slots: [{ signerAddr: ADDR, id: 0 }],
+      },
     });
 
     const submittedPeriod = await submitPeriod(
@@ -178,5 +216,120 @@ describe('submitPeriod', () => {
       timestamp: '0',
     });
     expect(submitPeriodWithCas).not.toBeCalled();
+  });
+
+  describe('period vote', () => {
+    test('not enough votes collected: 1/2', async () => {
+      const bridgeState = bridgeStateMock({
+        bridgeContract: bridgeContractMock({
+          returnPeriod: { timestamp: '0' },
+        }),
+        operatorContract: operatorContractMock(),
+        lastBlocksRoot: period.prevHash,
+        lastPeriodRoot: '0x1337',
+        currentState: {
+          periodVotes: {
+            [period.merkleRoot()]: [1],
+          },
+          slots: [{ signerAddr: ADDR, id: 0 }, { signerAddr: ADDR_1, id: 1 }],
+        },
+      });
+
+      const submittedPeriod = await submitPeriod(
+        period,
+        [{ signerAddr: ADDR, id: 0 }, { signerAddr: ADDR_1, id: 1 }],
+        0,
+        bridgeState,
+        {}
+      );
+
+      expect(submittedPeriod).toEqual({
+        timestamp: '0',
+      });
+      expect(submitPeriodWithCas).not.toBeCalled();
+    });
+
+    test('not enough votes collected: 2/4', async () => {
+      const bridgeState = bridgeStateMock({
+        bridgeContract: bridgeContractMock({
+          returnPeriod: { timestamp: '0' },
+        }),
+        operatorContract: operatorContractMock(),
+        lastBlocksRoot: period.prevHash,
+        lastPeriodRoot: '0x1337',
+        currentState: {
+          periodVotes: {
+            [period.merkleRoot()]: [1, 2],
+          },
+          slots: [
+            { signerAddr: ADDR, id: 0 },
+            { signerAddr: ADDR_1, id: 1 },
+            { signerAddr: ADDR_1, id: 2 },
+            { signerAddr: ADDR_1, id: 3 },
+          ],
+        },
+      });
+
+      const submittedPeriod = await submitPeriod(
+        period,
+        [
+          { signerAddr: ADDR, id: 0 },
+          { signerAddr: ADDR_1, id: 1 },
+          { signerAddr: ADDR_1, id: 2 },
+          { signerAddr: ADDR_1, id: 3 },
+        ],
+        0,
+        bridgeState,
+        {}
+      );
+
+      expect(submittedPeriod).toEqual({
+        timestamp: '0',
+      });
+      expect(submitPeriodWithCas).not.toBeCalled();
+    });
+
+    test('got enough votes: 3/4', async () => {
+      const bridgeState = bridgeStateMock({
+        bridgeContract: bridgeContractMock({
+          returnPeriod: { timestamp: '0' },
+        }),
+        operatorContract: operatorContractMock(),
+        lastBlocksRoot: period.prevHash,
+        lastPeriodRoot: '0x1337',
+        currentState: {
+          periodVotes: {
+            [period.merkleRoot()]: [0, 2, 3],
+          },
+          slots: [
+            { signerAddr: ADDR, id: 0 },
+            { signerAddr: ADDR_1, id: 1 },
+            { signerAddr: ADDR_1, id: 2 },
+            { signerAddr: ADDR_1, id: 3 },
+          ],
+        },
+      });
+
+      const submittedPeriod = await submitPeriod(
+        period,
+        [
+          { signerAddr: ADDR, id: 0 },
+          { signerAddr: ADDR_1, id: 1 },
+          { signerAddr: ADDR_1, id: 2 },
+          { signerAddr: ADDR_1, id: 3 },
+        ],
+        0,
+        bridgeState,
+        {}
+      );
+
+      expect(submittedPeriod).toEqual({
+        timestamp: '0',
+      });
+      expect(submitPeriodWithCas).toBeCalled();
+      expect(submitPeriodWithCas.mock.calls[0][3]).toEqual(
+        '0xb000000000000000000000000000000000000000000000000000000000000000'
+      );
+    });
   });
 });

--- a/src/txHelpers/submitPeriod.test.js
+++ b/src/txHelpers/submitPeriod.test.js
@@ -28,7 +28,6 @@ const bridgeStateMock = attrs => ({
   currentState: {
     periodVotes: {},
   },
-  periodsInFlight: {},
   ...attrs,
 });
 

--- a/src/utils/sendTransaction.js
+++ b/src/utils/sendTransaction.js
@@ -7,7 +7,7 @@
 
 const getRootGasPrice = require('./getRootGasPrice');
 
-module.exports = async function sendTransaction(web3, method, to, account) {
+module.exports = async (web3, method, to, account) => {
   const gas = Math.round(
     (await method.estimateGas({ from: account.address })) * 1.21
   );


### PR DESCRIPTION
- submission is done in a block handler, so that the node has time to collect votes
- temporary storing has of submission tx until it is mined. So that we don't submit same period twice

Resolves #309 
Requires #289 for client side to work with this change. Otherwise no data to construct CAS proofs