### PR TITLE
Add old events into ABIs

### DIFF
--- a/src/abis/exitHandler.js
+++ b/src/abis/exitHandler.js
@@ -671,6 +671,40 @@ module.exports = [
         name: 'amount',
         type: 'uint256',
       },
+    ],
+    name: 'ExitStarted',
+    type: 'event',
+    signature:
+      '0xaace06690e02011b548d8c5a74e1a678833d4136a56e657909fc6354bfb7c31f',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'txHash',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        name: 'outIndex',
+        type: 'uint8',
+      },
+      {
+        indexed: true,
+        name: 'color',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'exitor',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'amount',
+        type: 'uint256',
+      },
       {
         indexed: false,
         name: 'data',

--- a/src/abis/operator.js
+++ b/src/abis/operator.js
@@ -346,6 +346,35 @@ module.exports = [
     type: 'event',
   },
   {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        name: 'blocksRoot',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        name: 'slotId',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'periodRoot',
+        type: 'bytes32',
+      },
+    ],
+    name: 'Submission',
+    type: 'event',
+    signature:
+      '0x6690fe1f2634f1045e46d9adb5863d34ad6e548e6eb55fac8189444a403f8ee0',
+  },
+  {
     constant: false,
     inputs: [
       {


### PR DESCRIPTION
Resolves #324 

This solution may seem like a cheat comparing with bounty description, but:

1. It happens not so often to add a new complex system into the node. Less complexity, less bugs
2. Many things can be changed along with event signature and IMO we should think more about these cases, not about event decode
3. It may be a good idea to add a new event instead of changing the old one

With this PR events work fine, but i was not able to sync local node with testnet because of [this tx](https://testnet.leapdao.org/explorer/tx/0x26805fe0b0e1cf7ab4dfede7f19c76493b2ec9b4490a5b42ed467374b30b9b94). I've got `not touched 0x197970e48082cd46f277abdb8afe492bccd78300` error at height 43897 in tx handler (see 2.).

P. S.
Not quite sure what to do about bounty size 🤷‍♂ 

/cc @troggy 