### PR TITLE
feat: exclude exiting utxos from active utxo set

### DIFF
--- a/src/api/methods/getUnspent.js
+++ b/src/api/methods/getUnspent.js
@@ -1,9 +1,13 @@
 const { isValidAddress } = require('ethereumjs-util');
+const { omit } = require('lodash');
 const getColor = require('./getColor');
 const { filterUnspent } = require('../../utils');
 
 module.exports = async (bridgeState, address, colorOrAddress) => {
-  const { unspent } = bridgeState.currentState;
+  const unspent = omit(
+    bridgeState.currentState.unspent,
+    Object.keys(bridgeState.exitingUtxos)
+  );
   let color = colorOrAddress;
   if (isValidAddress(colorOrAddress)) {
     color = await getColor(bridgeState, colorOrAddress);

--- a/src/api/methods/getUnspent.test.js
+++ b/src/api/methods/getUnspent.test.js
@@ -40,7 +40,8 @@ const unspent = {
 const bridgeState = extraState => merge({
   currentState: {
     unspent
-  }
+  },
+  exitingUtxos: {}
 }, extraState);
 
 describe('getUnspent', () => {
@@ -136,6 +137,28 @@ describe('getUnspent', () => {
     }
 
     expect(error).toBe('Unknown token address');
+  });
+
+  test('unspents with unprocessed exits', async () => {
+    const state = bridgeState({
+      exitingUtxos: {
+        [out1]: {}
+      },
+    });
+
+    const unspents = await getUnspent(state);
+
+    // unspents shouldn't include out1 which is exiting
+    expect(unspents).toEqual([
+      {
+        outpoint: out0,
+        output: tx.outputs[0].toJSON(),
+      },
+      {
+        outpoint: out2,
+        output: tx.outputs[2].toJSON(),
+      },
+    ]);
   });
 
   test('empty unspent list', async () => {

--- a/src/api/methods/getUnspent.test.js
+++ b/src/api/methods/getUnspent.test.js
@@ -1,4 +1,5 @@
 const { Tx, Input, Outpoint, Output } = require('leap-core');
+const { merge } = require('lodash');
 const getUnspent = require('./getUnspent');
 
 const PRIV1 =
@@ -26,117 +27,110 @@ const tx = Tx.transfer(
   [new Output(100, A2, 0), new Output(200, A1, 0), new Output(300, A2, 1)]
 ).signAll(PRIV1);
 
+const out0 = new Outpoint(tx.hash(), 0).hex();
+const out1 = new Outpoint(tx.hash(), 1).hex();
+const out2 = new Outpoint(tx.hash(), 2).hex();
+
 const unspent = {
-  [new Outpoint(tx.hash(), 0).hex()]: tx.outputs[0].toJSON(),
-  [new Outpoint(tx.hash(), 1).hex()]: tx.outputs[1].toJSON(),
-  [new Outpoint(tx.hash(), 2).hex()]: tx.outputs[2].toJSON(),
+  [out0]: tx.outputs[0].toJSON(),
+  [out1]: tx.outputs[1].toJSON(),
+  [out2]: tx.outputs[2].toJSON(),
 };
+
+const bridgeState = extraState => merge({
+  currentState: {
+    unspent
+  }
+}, extraState);
 
 describe('getUnspent', () => {
   test('unspent for existent addr', async () => {
-    const state = {
-      unspent,
-    };
 
-    const unspent1 = await getUnspent({ currentState: state }, A1);
+    const unspent1 = await getUnspent(bridgeState(), A1);
     expect(unspent1).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 1).hex(),
+        outpoint: out1,
         output: tx.outputs[1].toJSON(),
       },
     ]);
 
-    const unspent2 = await getUnspent({ currentState: state }, A2);
+    const unspent2 = await getUnspent(bridgeState(), A2);
     expect(unspent2).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 0).hex(),
+        outpoint: out0,
         output: tx.outputs[0].toJSON(),
       },
       {
-        outpoint: new Outpoint(tx.hash(), 2).hex(),
+        outpoint: out2,
         output: tx.outputs[2].toJSON(),
       },
     ]);
   });
 
   test('all unspent', async () => {
-    const state = {
-      unspent,
-    };
-
-    const unspents = await getUnspent({ currentState: state });
+    const unspents = await getUnspent(bridgeState());
     expect(unspents).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 0).hex(),
+        outpoint: out0,
         output: tx.outputs[0].toJSON(),
       },
       {
-        outpoint: new Outpoint(tx.hash(), 1).hex(),
+        outpoint: out1,
         output: tx.outputs[1].toJSON(),
       },
       {
-        outpoint: new Outpoint(tx.hash(), 2).hex(),
+        outpoint: out2,
         output: tx.outputs[2].toJSON(),
       },
     ]);
   });
 
   test('unspent for existent addr for specific color', async () => {
-    const state = {
-      unspent,
-    };
-
-    const unspent1 = await getUnspent({ currentState: state }, A1, 0);
+    const unspent1 = await getUnspent(bridgeState(), A1, 0);
     expect(unspent1).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 1).hex(),
+        outpoint: out1,
         output: tx.outputs[1].toJSON(),
       },
     ]);
 
-    const unspent2 = await getUnspent({ currentState: state }, A1, '0');
+    const unspent2 = await getUnspent(bridgeState(), A1, '0');
     expect(unspent2).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 1).hex(),
+        outpoint: out1,
         output: tx.outputs[1].toJSON(),
       },
     ]);
   });
 
   test('unspent for existent addr for specific token', async () => {
-    const bridgeState = {
-      currentState: {
-        unspent,
-      },
+    const state = bridgeState({
       tokens: {
         erc20: [TOKEN_ADDR],
       },
-    };
+    });
 
-    const unspents = await getUnspent(bridgeState, A1, TOKEN_ADDR);
+    const unspents = await getUnspent(state, A1, TOKEN_ADDR);
     expect(unspents).toEqual([
       {
-        outpoint: new Outpoint(tx.hash(), 1).hex(),
+        outpoint: out1,
         output: tx.outputs[1].toJSON(),
       },
     ]);
   });
 
   test('unspent for existent addr for non-existing token', async () => {
-    const bridgeState = {
-      currentState: {
-        unspent,
-      },
+    const state = bridgeState({
       tokens: {
         erc20: [],
         erc721: [],
         erc1948: [],
       },
-    };
+    });
 
     let error;
     try {
-      await getUnspent(bridgeState, A1, TOKEN_ADDR);
+      await getUnspent(state, A1, TOKEN_ADDR);
     } catch (err) {
       error = err.message;
     }
@@ -145,10 +139,12 @@ describe('getUnspent', () => {
   });
 
   test('empty unspent list', async () => {
-    const state = {
-      unspent: {},
-    };
-    const unspents = await getUnspent({ currentState: state }, '0x000');
+    const state = bridgeState({
+      currentState: {
+        unspent: {},
+      }
+    });
+    const unspents = await getUnspent(state, '0x000');
     expect(unspents).toEqual([]);
   });
 });

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -80,6 +80,7 @@ module.exports = class BridgeState {
     this.submissions = [];
     this.periodHeights = {};
     this.submittedPeriods = {};
+    this.exitingUtxos = {};
 
     this.handleEvents = handleEvents({
       NewDeposit: ({ returnValues: event }) => {
@@ -151,6 +152,19 @@ module.exports = class BridgeState {
         });
       },
     });
+
+    this.handleExitingUtxos = handleEvents({
+      ExitStarted: ({ returnValues: event }) => {
+        const outpoint = new Outpoint(event.txHash, Number(event.outIndex));
+        this.exitingUtxos[outpoint.hex()] = {
+          txHash: event.txHash,
+          outIndex: Number(event.outIndex),
+          exitor: event.exitor,
+          color: event.color,
+          amount: event.amount,
+        };
+      },
+    });
   }
 
   async init() {
@@ -179,6 +193,16 @@ module.exports = class BridgeState {
       this.currentPeriod = new Period(this.lastBlocksRoot);
     }
 
+    this.exitEventSubscription = new ContractsEventsSubscription(
+      this.web3,
+      [this.exitHandlerContract],
+      [],
+      blockNumber - this.bridgeDelay,
+      'ExitStarted'
+    );
+    this.exitEventSubscription.on('newEvents', this.handleExitingUtxos);
+    this.exitEventSubscription.init();
+    
     logNode('Synced');
   }
 

--- a/src/bridgeState.test.js
+++ b/src/bridgeState.test.js
@@ -218,4 +218,45 @@ describe('BridgeState', () => {
       },
     });
   });
+
+  test('Exits handling', async () => {
+    const bridgeContract = {
+      methods: {
+        genesisBlockNumber: () => ({
+          call: async () => 5,
+        }),
+      },
+    };
+    const state = createInstance(
+      {
+        eth: {
+          getBlockNumber: async () => 5,
+        },
+      },
+      bridgeContract,
+      {
+        async getLastBlockSynced() {
+          return 0;
+        },
+        async storeBlock() {
+          return null;
+        },
+      },
+      {}
+    );
+    await state.init();
+    await Promise.all(EVENT_BATCHES.map(events => state.handleExitingUtxos(events)));
+    expect(state.exitingUtxos).toEqual({
+      '0x2bc83fb4a5ff059e8dfc6ac1a47903b133f484d8aeac943489841cc1cbb3bb0b00': {
+        txHash:
+          '0x2bc83fb4a5ff059e8dfc6ac1a47903b133f484d8aeac943489841cc1cbb3bb0b',
+        outIndex: 0,
+        exitor: '0xB8205608d54cb81f44F263bE086027D8610F3C94',
+        color: '0',
+        amount: '100',
+      },
+    });
+
+    expect(state.exits).toEqual({});
+  });
 });

--- a/src/tx/applyTx/checkExit.js
+++ b/src/tx/applyTx/checkExit.js
@@ -32,4 +32,6 @@ module.exports = (state, tx, bridgeState) => {
   ) {
     throw new Error('Trying to submit incorrect exit');
   }
+
+  delete bridgeState.exitingUtxos[prevout.hex()];
 };

--- a/src/tx/applyTx/checkExit.test.js
+++ b/src/tx/applyTx/checkExit.test.js
@@ -3,7 +3,11 @@ const checkExit = require('./checkExit');
 
 const ADDR_1 = '0x4436373705394267350db2c06613990d34621d69';
 
-const makeExitMock = (exitor, amount, color) => {
+const makeExitMock = (exitor, amount, color, outpoint) => {
+  const exitingUtxos = {};
+  if (outpoint) {
+    exitingUtxos[outpoint.hex()] = {};
+  }
   return {
     exits: new Proxy(
       {},
@@ -11,6 +15,7 @@ const makeExitMock = (exitor, amount, color) => {
         get: () => ({ exitor, amount, color }),
       }
     ),
+    exitingUtxos
   };
 };
 
@@ -29,8 +34,11 @@ describe('checkExit', () => {
       },
     };
 
+    const bridgeState = makeExitMock(ADDR_1, '500', 0, outpoint);
+
     const exit = Tx.exit(new Input(outpoint));
-    checkExit(state, exit, makeExitMock(ADDR_1, '500', 0));
+    checkExit(state, exit, bridgeState);
+    expect(bridgeState.exitingUtxos).toEqual({});
   });
 
   test('not 1 input', () => {

--- a/src/utils/ContractsEventsSubscription.js
+++ b/src/utils/ContractsEventsSubscription.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the Mozilla Public License Version 2.0
  * found in the LICENSE file in the root directory of this source tree.
  */
-
+const EventEmitter = require('events');
 const getBlockAverageTime = require('../utils/getBlockAverageTime');
 
 const BATCH_SIZE = 5000;
@@ -26,8 +26,9 @@ async function getPastEvents(contract, eventName, fromBlock, toBlock) {
   return events.reduce((result, ev) => result.concat(ev), []);
 }
 
-module.exports = class ContractsEventsSubscription {
+module.exports = class ContractsEventsSubscription extends EventEmitter {
   constructor(web3, contracts, eventsBuffer, fromBlock = null, eventName = 'allEvents') {
+    super();
     this.fromBlock = fromBlock;
     this.web3 = web3;
     this.contracts = contracts;
@@ -67,6 +68,7 @@ module.exports = class ContractsEventsSubscription {
 
     this.fromBlock = blockNumber;
 
+    this.emit('newEvents', events);
     return events;
   }
 };

--- a/src/utils/ContractsEventsSubscription.test.js
+++ b/src/utils/ContractsEventsSubscription.test.js
@@ -92,3 +92,21 @@ test('specific event', async () => {
   const events = await sub.init();
   expect(events).toEqual([{ event: 'NewExit' }]);
 });
+
+test('event emitter', async () => {
+  const contractEvents = [
+    { event: 'NewDeposit' },
+    { event: 'NewDeposit' },
+    { event: 'NewExit' },
+  ];
+  const sub = new ContractsEventsSubscription(
+    mockWeb3(10),
+    mockContracts(() => contractEvents),
+    []
+  );
+
+  sub.addListener('newEvents', (events) => {
+    expect(events).toEqual(contractEvents);
+  })
+  await sub.init();
+});

--- a/src/utils/ContractsEventsSubscription.test.js
+++ b/src/utils/ContractsEventsSubscription.test.js
@@ -71,3 +71,24 @@ test('init', async () => {
   const events = await sub.init();
   expect(events).toEqual(contractEvents);
 });
+
+test('specific event', async () => {
+  const contractEvents = [
+    { event: 'NewDeposit' },
+    { event: 'NewDeposit' },
+    { event: 'NewExit' },
+  ];
+  const sub = new ContractsEventsSubscription(
+    mockWeb3(10),
+    mockContracts((event) => {
+      expect(event).toBe('NewExit');
+      return contractEvents.slice(-1);
+    }),
+    [],
+    null,
+    'NewExit'
+  );
+
+  const events = await sub.init();
+  expect(events).toEqual([{ event: 'NewExit' }]);
+});

--- a/src/utils/__mocks__/ContractsEventsSubscription.js
+++ b/src/utils/__mocks__/ContractsEventsSubscription.js
@@ -1,7 +1,10 @@
+const EventEmitter = require('events');
+
 let eventsBatches = [];
 
-class ContractsEventsSubscriptionMock {
+class ContractsEventsSubscriptionMock extends EventEmitter {
   constructor() {
+    super();
     this.fetchEvents = this.fetchEvents.bind(this);
     this.fetchCounts = 0;
     this.handlers = [];
@@ -21,7 +24,7 @@ class ContractsEventsSubscriptionMock {
     this.fetchCounts += 1;
 
     this.handlers.forEach(handler => handler(events));
-
+    this.emit('newEvents', events);
     return events;
   }
 }


### PR DESCRIPTION
Resolves #284 

- add additional handling for `ExitStarted` event: no consensus delay, store exiting utxos in a bridge state
- filter exiting utxos from the results of `getUnspent` RPC

---

Possible way to verify:

1. Run local env using this PR branch for leap-node (`yarn start` in integration tests)
2. push chain to the next period (block 36)
3. Run local bridge UI and start an exit.
4. Notice that the exited UTXO disappears before Exit transaction is included. Increase bridge delay (e.g. add `BRIDGE_DELAY: 20` [here](https://github.com/leapdao/integration-tests/blob/master/src/run.js#L38)) to slow down Exit tx inclusion if needed.