### PR TITLE
feat: export epochLength in a bridgeState

### DIFF
--- a/src/tx/applyTx/checkEpochLength.js
+++ b/src/tx/applyTx/checkEpochLength.js
@@ -21,5 +21,5 @@ module.exports = (state, tx, bridgeState) => {
 
   state.epoch.epochLengthIndex += 1;
   state.epoch.epochLength = tx.options.epochLength;
-  bridgeState.epochLength = state.epoch.epochLength;
+  bridgeState.epochLength = tx.options.epochLength;
 };

--- a/src/tx/applyTx/checkEpochLength.js
+++ b/src/tx/applyTx/checkEpochLength.js
@@ -21,4 +21,5 @@ module.exports = (state, tx, bridgeState) => {
 
   state.epoch.epochLengthIndex += 1;
   state.epoch.epochLength = tx.options.epochLength;
+  bridgeState.epochLength = state.epoch.epochLength;
 };

--- a/src/tx/applyTx/checkEpochLength.test.js
+++ b/src/tx/applyTx/checkEpochLength.test.js
@@ -20,11 +20,14 @@ describe('checkEpochLength', () => {
     const state = getInitialState();
     const epochLength = Tx.epochLength(4);
 
-    checkEpochLength(state, epochLength, {
+    const bridgeState = {
       epochLengths: [4],
-    });
+    };
+
+    checkEpochLength(state, epochLength, bridgeState);
 
     expect(state.epoch.epochLength).toBe(4);
+    expect(bridgeState.epochLength).toBe(4);
   });
 
   test('series of txs', () => {

--- a/src/tx/applyTx/checkEpochLength.test.js
+++ b/src/tx/applyTx/checkEpochLength.test.js
@@ -20,14 +20,11 @@ describe('checkEpochLength', () => {
     const state = getInitialState();
     const epochLength = Tx.epochLength(4);
 
-    const bridgeState = {
+    checkEpochLength(state, epochLength, {
       epochLengths: [4],
-    };
-
-    checkEpochLength(state, epochLength, bridgeState);
+    });
 
     expect(state.epoch.epochLength).toBe(4);
-    expect(bridgeState.epochLength).toBe(4);
   });
 
   test('series of txs', () => {
@@ -39,11 +36,14 @@ describe('checkEpochLength', () => {
     });
 
     const epochLength2 = Tx.epochLength(3);
-    checkEpochLength(state, epochLength2, {
+    const bridgeState = {
+      epochLength: 4,
       epochLengths: [4, 3],
-    });
+    };
+    checkEpochLength(state, epochLength2, bridgeState);
 
     expect(state.epoch.epochLength).toBe(3);
+    expect(bridgeState.epochLength).toBe(3);
   });
 
   test('epoch length mismatch', () => {


### PR DESCRIPTION
So later on it can be exposed outside via plasma_getState.

Accompanies #340