### PR TITLE
fix: event subscription code reads the same block twice.

### DIFF
--- a/src/utils/ContractsEventsSubscription.js
+++ b/src/utils/ContractsEventsSubscription.js
@@ -64,7 +64,7 @@ module.exports = class ContractsEventsSubscription {
       this.eventsBuffer.push(event);
     }
 
-    this.fromBlock = blockNumber;
+    this.fromBlock = blockNumber + 1;
 
     return events;
   }


### PR DESCRIPTION
`ContractsEventsSubscription` class reads events in interval `[fromBlock,toBlock]` every root chain block. After each read, it does `fromBlock = toBlock` assignment, to continue reading from `toBlock`.

However, both boundaries are included in the iteration. So block at `toBlock` height is already been read within `[fromBlock,toBlock]` iteration. To read the next portion, we have to start from `toBlock + 1`, not from `toBlock`.

Relates #340