### PR TITLE
fix: node skips some epoch length txs making bridgeState corrupt

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jsbi": "^3.0.0",
     "jsbi-utils": "^1.0.0",
     "jsondiffpatch": "^0.2.5",
-    "leap-core": "^0.34.2",
+    "leap-core": "^0.36.2-beta",
     "level": "^4.0.0",
     "lodash": "^4.17.13",
     "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jsbi": "^3.0.0",
     "jsbi-utils": "^1.0.0",
     "jsondiffpatch": "^0.2.5",
-    "leap-core": "^0.36.2-beta",
+    "leap-core": "^0.37.0",
     "level": "^4.0.0",
     "lodash": "^4.17.13",
     "lodash.get": "^4.4.2",

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -131,8 +131,12 @@ module.exports = class BridgeState {
           array.push(event.tokenAddr);
         }
       },
-      EpochLength: ({ returnValues: event }) => {
-        this.epochLengths.push(Number(event.epochLength));
+      EpochLength: (event) => {
+        const { blockNumber, returnValues } = event;
+        this.epochLengths.push([
+          Number(returnValues.epochLength),
+          Number(blockNumber),
+        ]);
       },
       MinGasPrice: ({ returnValues: event }) => {
         this.minGasPrices.push(Number(event.minGasPrice));

--- a/src/bridgeState.test.js
+++ b/src/bridgeState.test.js
@@ -6,9 +6,9 @@ jest.mock('./utils/ContractsEventsSubscription');
 const ContractsEventsSubscription = require('./utils/ContractsEventsSubscription');
 
 const EVENT_BATCHES = [
-  [{ event: 'EpochLength', returnValues: { epochLength: '4' } }],
+  [{ event: 'EpochLength', blockNumber: 1, returnValues: { epochLength: '4' } }],
   [{ event: 'MinGasPrice', returnValues: { minGasPrice: '1000000' } }],
-  [{ event: 'EpochLength', returnValues: { epochLength: '3' } }],
+  [{ event: 'EpochLength', blockNumber: 5, returnValues: { epochLength: '3' } }],
   [
     {
       event: 'NewDeposit',
@@ -191,7 +191,7 @@ describe('BridgeState', () => {
     );
     await state.init();
     await Promise.all(EVENT_BATCHES.map(events => state.handleEvents(events)));
-    expect(state.epochLengths).toEqual([4, 3]);
+    expect(state.epochLengths).toEqual([[4, 1], [3, 5]]);
     expect(state.minGasPrices).toEqual([1000000]);
     expect(state.deposits).toEqual({
       '0': {

--- a/src/eventsRelay.js
+++ b/src/eventsRelay.js
@@ -75,9 +75,9 @@ module.exports = class EventsRelay {
         );
         this.sendDelayed(tx);
       },
-      EpochLength: async event => {
+      EpochLength: async (event) => {
         const { epochLength } = event.returnValues;
-        const tx = Tx.epochLength(Number(epochLength));
+        const tx = Tx.epochLength(Number(epochLength), Number(event.blockNumber));
         this.sendDelayed(tx);
       },
       MinGasPrice: async event => {

--- a/src/tx/applyTx/checkEpochLength.js
+++ b/src/tx/applyTx/checkEpochLength.js
@@ -8,7 +8,7 @@
 const { Type } = require('leap-core');
 
 module.exports = (state, tx, bridgeState) => {
-  if (tx.type !== Type.EPOCH_LENGTH) {
+  if (tx.type !== Type.EPOCH_LENGTH_V1 && tx.type !== Type.EPOCH_LENGTH_V2) {
     throw new Error('epochLength tx expected');
   }
 

--- a/src/tx/applyTx/checkEpochLength.js
+++ b/src/tx/applyTx/checkEpochLength.js
@@ -12,9 +12,13 @@ module.exports = (state, tx, bridgeState) => {
     throw new Error('epochLength tx expected');
   }
 
+  const [expectedEpochLength, expectedBlockHeight] = bridgeState.epochLengths[
+    state.epoch.epochLengthIndex + 1
+  ];
+  const { blockHeight, epochLength } = tx.options;
   if (
-    bridgeState.epochLengths[state.epoch.epochLengthIndex + 1] !==
-    tx.options.epochLength
+    expectedEpochLength !== epochLength ||
+    (blockHeight && blockHeight !== expectedBlockHeight)
   ) {
     throw new Error('Wrong epoch length');
   }

--- a/src/tx/applyTx/checkEpochLength.test.js
+++ b/src/tx/applyTx/checkEpochLength.test.js
@@ -21,7 +21,7 @@ describe('checkEpochLength', () => {
     const epochLength = Tx.epochLength(4, 2);
 
     checkEpochLength(state, epochLength, {
-      epochLengths: [4],
+      epochLengths: [[4, 2]],
     });
 
     expect(state.epoch.epochLength).toBe(4);
@@ -32,13 +32,13 @@ describe('checkEpochLength', () => {
 
     const epochLength1 = Tx.epochLength(4, 2);
     checkEpochLength(state, epochLength1, {
-      epochLengths: [4],
+      epochLengths: [[4, 2]],
     });
 
-    const epochLength2 = Tx.epochLength(3, 2);
+    const epochLength2 = Tx.epochLength(3, 5);
     const bridgeState = {
       epochLength: 4,
-      epochLengths: [4, 3],
+      epochLengths: [[4, 2], [3, 5]],
     };
     checkEpochLength(state, epochLength2, bridgeState);
 
@@ -52,7 +52,13 @@ describe('checkEpochLength', () => {
 
     expect(() => {
       checkEpochLength(state, epochLength, {
-        epochLengths: [5],
+        epochLengths: [[5, 2]],
+      });
+    }).toThrow('Wrong epoch length');
+
+    expect(() => {
+      checkEpochLength(state, epochLength, {
+        epochLengths: [[4, 1]],
       });
     }).toThrow('Wrong epoch length');
   });

--- a/src/tx/applyTx/checkEpochLength.test.js
+++ b/src/tx/applyTx/checkEpochLength.test.js
@@ -18,7 +18,7 @@ describe('checkEpochLength', () => {
 
   test('successful tx', () => {
     const state = getInitialState();
-    const epochLength = Tx.epochLength(4);
+    const epochLength = Tx.epochLength(4, 2);
 
     checkEpochLength(state, epochLength, {
       epochLengths: [4],
@@ -30,12 +30,12 @@ describe('checkEpochLength', () => {
   test('series of txs', () => {
     const state = getInitialState();
 
-    const epochLength1 = Tx.epochLength(4);
+    const epochLength1 = Tx.epochLength(4, 2);
     checkEpochLength(state, epochLength1, {
       epochLengths: [4],
     });
 
-    const epochLength2 = Tx.epochLength(3);
+    const epochLength2 = Tx.epochLength(3, 2);
     const bridgeState = {
       epochLength: 4,
       epochLengths: [4, 3],
@@ -48,7 +48,7 @@ describe('checkEpochLength', () => {
 
   test('epoch length mismatch', () => {
     const state = getInitialState();
-    const epochLength = Tx.epochLength(4);
+    const epochLength = Tx.epochLength(4, 2);
 
     expect(() => {
       checkEpochLength(state, epochLength, {

--- a/src/tx/applyTx/index.js
+++ b/src/tx/applyTx/index.js
@@ -12,7 +12,8 @@ const { checkOutpoints, removeInputs, addOutputs } = require('./utils');
 
 const checks = {
   [Type.DEPOSIT]: require('./checkDeposit'),
-  [Type.EPOCH_LENGTH]: require('./checkEpochLength'),
+  [Type.EPOCH_LENGTH_V1]: require('./checkEpochLength'),
+  [Type.EPOCH_LENGTH_V2]: require('./checkEpochLength'),
   [Type.MIN_GAS_PRICE]: require('./checkMinGasPrice'),
   [Type.EXIT]: require('./checkExit'),
   [Type.TRANSFER]: require('./checkTransfer'),

--- a/src/txHelpers/printTx.js
+++ b/src/txHelpers/printTx.js
@@ -11,7 +11,8 @@ module.exports = (state, tx) => {
       case Type.DEPOSIT: {
         return `deposit: ${printOutput(tx.outputs[0], '+')}`;
       }
-      case Type.EPOCH_LENGTH: {
+      case Type.EPOCH_LENGTH_V1:
+      case Type.EPOCH_LENGTH_V2: {
         return `epochLength: ${tx.options.epochLength}`;
       }
       case Type.MIN_GAS_PRICE: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4134,10 +4134,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@^0.34.2:
-  version "0.34.2"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.34.2.tgz#24c78de02c1a7730d15beaac0a363980a8850e7a"
-  integrity sha512-gHzSJ+tYvnRCiY3WfK8oP8SjQ4xTh1EFPxQbm6+5kTGuDBTzWD/LhOHiRZ+s3/9IpkiCPppu/9Ae+DBjUnPxhg==
+leap-core@^0.36.2-beta:
+  version "0.36.2-beta"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.36.2-beta.tgz#b02490f2003ec4931ad41f384c67573693727549"
+  integrity sha512-CN9TYEnScz8k1q+c7a+uBWHHoEZUpuM8CbmjFrtOgr1+dRGVh9kY/agDUg+D6NKt1x0VT6pOD47hTL76PDJMSA==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4134,10 +4134,10 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-leap-core@^0.36.2-beta:
-  version "0.36.2-beta"
-  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.36.2-beta.tgz#b02490f2003ec4931ad41f384c67573693727549"
-  integrity sha512-CN9TYEnScz8k1q+c7a+uBWHHoEZUpuM8CbmjFrtOgr1+dRGVh9kY/agDUg+D6NKt1x0VT6pOD47hTL76PDJMSA==
+leap-core@^0.37.0:
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/leap-core/-/leap-core-0.37.0.tgz#1f17957d33bccca130c8e167af2c756a8700d0f6"
+  integrity sha512-9Lj2ibtoDLe9D6++R9CclWMCv/Nf+jiidRRRqgukOOW5b5NdlodSJQMpHa1nw1EL50sl3UImb2GUiYQZJCmFMw==
   dependencies:
     "@types/web3" "^1.0.18"
     ethereumjs-util "6.0.0"


### PR DESCRIPTION
Requires: leapdao/leap-core#155, #348
Resolves #340 
Test to reproduce with: leapdao/integration-tests#69

## Tendermint replay protection

Tendermint has a [build-in replay protection](https://tendermint.com/docs/app-dev/app-development.html#replay-protection) which will reject the same tx from being added to the mempool twice. It seems to work by comparing raw tx bytes. Should two transactions have the same raw bytes, the second one will not make it to the mempool.

Now, EpochLength transaction in leap-core is merely a `[type,epochLength]` tuple. `Tx.epochLength(X)` will have the same raw bytes for the same `X`. Consider the following pretty valid transaction flow:

```
1. Tx.epochLength(2)
2. Tx.epochLength(4)
3. Tx.epochLength(2)
```

The third transaction will be rejected by tendermint's replay protection.

## How it affects leap-node

The node listens for root chain events, including `EpochLength` event. Everytime event comes, the node
a) keeps record of the epoch length from event (in the `bridgeState.epochLengths` list). [bridgeState](https://github.com/leapdao/leap-node/blob/5195438c54b7c2670e7314d102b690255b4a203b/src/bridgeState.js#L135)
b) creates `epochLength` transaction and relays it. [eventsRelay](https://github.com/leapdao/leap-node/blob/5195438c54b7c2670e7314d102b690255b4a203b/src/eventsRelay.js#L80)
c) handles `epochLength` tx, once received through ABCI from tendermint. [checkEpochLength](https://github.com/leapdao/leap-node/blob/5195438c54b7c2670e7314d102b690255b4a203b/src/tx/applyTx/checkEpochLength.js#L10)

The step (c) expects all the a,b,c steps always executed for every `EpochLength` event. However, if the node receives two `EpochLength(X)` events for the same epoch length, only steps (a) and (b) will be executed. Step (c) would never happen for the second event, because the transaction created on (b) will be rejected by Tendermint's replay protection. In the end, we have `bridgeState.epochLength` mutated by (a), which will make `checkEpochLength` fail for any further epoch length tx.

## Proposed solution

Add more differentiation to EpochLength transactions. I suggest adding blockHeight to it. See: https://github.com/leapdao/leap-core/pull/155

These two things needs to be merged first for the fix to work: leapdao/leap-core#155, #348