### PR TITLE
fix: check bridge always return success

### DIFF
--- a/lotion/lib/abci-app.js
+++ b/lotion/lib/abci-app.js
@@ -189,7 +189,7 @@ module.exports = function configureABCIServer({
   abciApp.checkBridge = async ({ height }) => {
     const rsp = {};
     for (let i = 0; i < periodMiddleware.length; i += 1) {
-      await periodMiddleware[i](rsp, chainInfo, height);
+      await periodMiddleware[i](rsp, store, chainInfo, height);
     }
     return { status: rsp.status };
   };

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -11,6 +11,13 @@ const submitPeriod = jest.requireMock('../txHelpers/submitPeriod');
 const ADDR = '0x4436373705394267350db2c06613990d34621d69';
 const ADDR_2 = '0x4436373705394267350db2c06613990d34621d61';
 
+const SUBMITTED_PERIOD = {
+  prevHash: '0x000002',
+  merkleRoot() {
+    return '0x000022';
+  },
+};
+
 const NON_EXISTENT_PERIOD = {
   prevHash: '0x000001',
   merkleRoot() {
@@ -32,7 +39,8 @@ describe('updatePeriod', () => {
     expect(bridgeState.currentPeriod.prevHash).toBe(
       NON_EXISTENT_PERIOD.merkleRoot()
     );
-    expect(bridgeState.previousPeriod).toBe(NON_EXISTENT_PERIOD);
+    expect(bridgeState.pendingPeriod).toBe(NON_EXISTENT_PERIOD);
+    expect(bridgeState.previousPeriod).toBe(undefined);
     expect(bridgeState.periodHeights[NON_EXISTENT_PERIOD.merkleRoot()]).toBe(
       32
     );
@@ -60,12 +68,13 @@ describe('updatePeriod', () => {
       );
 
       expect(bridgeState.currentPeriod).toBe(NON_EXISTENT_PERIOD);
-      expect(bridgeState.previousPeriod).toBe(undefined);
+      expect(bridgeState.pendingPeriod).toBe(undefined);
     });
 
     test('submit period if enough period votes and period pending', async () => {
       const bridgeState = {
-        previousPeriod: NON_EXISTENT_PERIOD,
+        previousPeriod: SUBMITTED_PERIOD,
+        pendingPeriod: NON_EXISTENT_PERIOD,
         submittedPeriods: {},
         periodHeights: {
           [NON_EXISTENT_PERIOD.merkleRoot()]: 32,
@@ -88,6 +97,8 @@ describe('updatePeriod', () => {
         32,
         bridgeState
       );
+
+      expect(bridgeState.previousPeriod).toBe(NON_EXISTENT_PERIOD);
     });
 
     test('do nothing if not enough period votes', async () => {

--- a/src/period/index.js
+++ b/src/period/index.js
@@ -11,9 +11,12 @@ const { logPeriod } = require('../utils/debug');
 
 module.exports = (bridgeState, sender) => async (
   rsp,
+  state,
   chainInfo
 ) => {
   const height = chainInfo.height - 32;
+
+  logPeriod('checkBridge');
 
   if (height <= 0 || !bridgeState.previousPeriod) {
     // genesis height doesn't need check
@@ -21,11 +24,12 @@ module.exports = (bridgeState, sender) => async (
     return;
   }
 
-  logPeriod('checkBridge');
+  logPeriod('checkBridge. Period: ', bridgeState.previousPeriod.merkleRoot());
+
   // use a timeout to relax race conditions (if period submission is fast)
   await new Promise(resolve => {
     setTimeout(async () => {
-      await submitPeriodVote(bridgeState.previousPeriod, bridgeState, sender);
+      await submitPeriodVote(bridgeState.previousPeriod, state, bridgeState, sender);
 
       const contractPeriod = await submitPeriod(
         bridgeState.previousPeriod,

--- a/src/period/index.js
+++ b/src/period/index.js
@@ -11,10 +11,9 @@ const { logPeriod } = require('../utils/debug');
 
 module.exports = (bridgeState, sender) => async (
   rsp,
-  chainInfo,
-  chainHeight
+  chainInfo
 ) => {
-  const height = chainHeight - 32;
+  const height = chainInfo.height - 32;
 
   if (height <= 0 || !bridgeState.previousPeriod) {
     // genesis height doesn't need check

--- a/src/period/period.test.js
+++ b/src/period/period.test.js
@@ -7,6 +7,8 @@ const submitPeriodVote = require('../period/submitPeriodVote');
 
 const sender = () => {};
 
+const state = {};
+
 const EXISTENT_PERIOD = {
   prevHash: '0x000000',
   merkleRoot() {
@@ -24,7 +26,7 @@ const NON_EXISTENT_PERIOD = {
 describe('Period handler', () => {
   test('Do not check genesis period', async () => {
     const rsp = {};
-    await periodHandler({})(rsp, { height: 32 });
+    await periodHandler({})(rsp, state, { height: 32 });
     expect(rsp.status).toBe(1);
   });
 
@@ -37,9 +39,10 @@ describe('Period handler', () => {
       },
       checkCallsCount: 0,
     };
-    await periodHandler(bridgeState, sender)(rsp, { height: 64 });
+    await periodHandler(bridgeState, sender)(rsp, state, { height: 64 });
     expect(submitPeriodVote).toBeCalledWith(
       EXISTENT_PERIOD,
+      state,
       bridgeState,
       sender
     );
@@ -56,7 +59,7 @@ describe('Period handler', () => {
       },
       checkCallsCount: 0,
     };
-    await periodHandler(bridgeState)(rsp, { height: 64 });
+    await periodHandler(bridgeState)(rsp, state, { height: 64 });
     expect(rsp.status).toBe(1);
   });
 });


### PR DESCRIPTION
Due to the [bug](https://github.com/leapdao/tendermint/pull/10) in our tendermint fork, `chainHeight` is always 0 in a period handler. We didn't use it though for some reason and took block height from `chainInfo` instead. However, it was changed in April and we missed the fact that `chainHeight` is always 0, thus making checkBridge ABCI to always succeed without checking anything.

As a a side effect, all the CAS-related changes in period handler were never called and thus never tested in a wild.

Resolves #326 

- [x] make the height check work again
- [x] make period handler work with CAS 

## Solution for CAS

In checkBridge we don't want to check periods which don't have enough votes and hence not yet submitted.
I propose to track those as `pendingPeriod`.

Every 32nd block we want to:
1. keep the current period as `pendingPeriod` until we collect enough votes
2. start a new period right away

Once we collect enough period votes, we submit the pending period and it becomes `previousPeriod`.
The checkBridge code still tracks period submission via `previousPeriod`.

To illustrate:

`previousPeriod` — period in green
`pendingPeriod` — period in blue
`currentPeriod` — period in yellow

![image](https://user-images.githubusercontent.com/163447/68389841-eea75800-0174-11ea-83e1-3158a8a70558.png)
