### PR TITLE
feat: add rootNetwork CLI arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Your local port `9999` forwards now to the remote host on address `127.0.0.1` an
 - `config` — path to config file or node's JSON RPC url (eg https://testnet-2.leapdao.org)
 - `version` — print version of the node
 - `dataPath` — path to folder with network data (default: `~/.lotion/networks/<network>—<networkdId>`)
+- `rootNetwork` — root chain provider url (e.g. `https://rinkeby.unfura.io`)
 
 ### Config file options
 ```
@@ -72,7 +73,7 @@ Your local port `9999` forwards now to the remote host on address `127.0.0.1` an
 - `bridgeAddr` — leap [Bridge](https://github.com/leapdao/leap-contracts) contract address
 - `operatorAddr` — leap [Operator](https://github.com/leapdao/leap-contracts) contract address
 - `exitHandlerAddr` — leap [ExitHandler](https://github.com/leapdao/leap-contracts) contract address
-- `rootNetwork` — Ethereum provider URL (e.g. `https://rinkeby.unfura.io`)
+- `rootNetwork` — root chain provider url (e.g. `https://rinkeby.unfura.io`)
 - `rootNetworkId` — NetworkId (called also `chainId`) of the network.
 - `genesis` — genesis string
 - `network` — plasma network name

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function run() {
   const config = await (async () => {
     let result;
     try {
-      result = readConfig(cliArgs.config);
+      result = readConfig(cliArgs.config, cliArgs.rootNetwork);
     } catch (err) {
       console.error(err.message);
       process.exit(0);

--- a/src/utils/cliArgs.js
+++ b/src/utils/cliArgs.js
@@ -120,6 +120,12 @@ const options = [
     env: 'DATA_PATH',
     help: 'Path to lotion folder',
   },
+  {
+    names: ['rootNetwork'],
+    type: 'string',
+    env: 'ROOT_NETWORK',
+    help: 'Root chain provider URL. Overrides rootNetwork from config file',
+  },
 ];
 
 const parser = dashdash.createParser({ options });

--- a/src/utils/readConfig.js
+++ b/src/utils/readConfig.js
@@ -40,7 +40,8 @@ const readConfigFile = async configPath => {
   return JSON.parse(await readFile(configPath));
 };
 
-const updateNetwork = async config => {
+const updateNetwork = async (config, cliRootNetwork) => {
+  config.rootNetwork = cliRootNetwork || config.rootNetwork;
   if (!config.rootNetwork) {
     throw new Error(
       'rootNetwork is not defined, please specify it in the config file.'
@@ -65,7 +66,7 @@ const updateNetwork = async config => {
 
 const urlRegex = /^https{0,1}:\/\//;
 
-module.exports = async configPath => {
+module.exports = async (configPath, cliRootNetwork) => {
   let config = urlRegex.test(configPath)
     ? await fetchNodeConfig(configPath)
     : await readConfigFile(configPath);
@@ -74,7 +75,7 @@ module.exports = async configPath => {
     throw new Error('exitHandlerAddr is required');
   }
 
-  config = await updateNetwork(config);
+  config = await updateNetwork(config, cliRootNetwork);
 
   return Object.assign({}, defaultConfig, config);
 };

--- a/src/utils/readConfig.test.js
+++ b/src/utils/readConfig.test.js
@@ -35,6 +35,20 @@ describe('readConfig', () => {
     });
   });
 
+  test('with rootNetwork from CLI', async () => {
+    Web3.__setMethodMock('eth.net.getId', () => 5777);
+
+    const result = await readConfig('./config.json', 'http://unfura.io/');
+    expect(result).toEqual({
+      exitHandlerAddr: '0x000',
+      network: 'testnet',
+      rootNetwork: 'http://unfura.io/',
+      rootNetworkId: 5777,
+      eventsDelay: 0,
+      bridgeDelay: 0,
+    });
+  });
+
   test('fetch node config', async () => {
     Web3.__setMethodMock('getConfig', () => ({
       exitHandlerAddr: '0x000',


### PR DESCRIPTION
Follow up for #353 

/cc @vrde 

Allows to do things like (needed for https://github.com/leapdao/integration-tests/issues/54):

```
curl -O https://raw.githubusercontent.com/leapdao/leap-node/master/presets/leap-testnet.json
leap-node --config=./leap-testnet.json --rootNetwork=https://rinkeby.infura.io/v3/XXXXXX
```