### PR TITLE
fix: proper error handling for period submission.

### DIFF
--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -26,7 +26,6 @@ module.exports = async (state, chainInfo, bridgeState, sender) => {
           bridgeState.periodHeights[pendingPeriodRoot],
           bridgeState
         );
-        bridgeState.submittedPeriods[pendingPeriodRoot] = true;
       } catch (err) {
         /* istanbul ignore next */
         logPeriod(`submit period: ${err}`);

--- a/src/txHelpers/submitPeriod.js
+++ b/src/txHelpers/submitPeriod.js
@@ -99,18 +99,17 @@ module.exports = async (period, slots, height, bridgeState) => {
       ),
       bridgeState.operatorContract.options.address,
       bridgeState.account
-    ).catch(
-      /* istanbul ignore next */ () => {
-        delete inFlight[periodRoot];
-        logError(height);
-      }
-    );
+    ).catch((e) => {
+      logPeriod('submitPeriod error', e);
+      delete inFlight[periodRoot];
+      logError(height);
+    });
 
     tx.then(receipt => {
       logPeriod('submitPeriod tx', receipt);
       delete inFlight[periodRoot];
-      if (receipt && receipt.status === 1) {
-        bridgeState.submittedPeriod[periodRoot] = true;
+      if (receipt && receipt.status) {
+        bridgeState.submittedPeriods[periodRoot] = true;
       }
     });
   }


### PR DESCRIPTION
We were prematurely marking the period as submitted (in updatePeriod) — at [this](https://github.com/leapdao/leap-node/compare/fix/submit-period?expand=1#diff-786c9ee7cb87a989994653f4a23150a6L29) point period submission may not happen yet and may never happen (e.g. due to error).
The code which was supposed to do that in `submitPeriod` was [broken](https://github.com/leapdao/leap-node/compare/fix/submit-period?expand=1#diff-8372d553eb3845a04d491ab410b2620aR112) and [never really called](https://github.com/leapdao/leap-node/compare/fix/submit-period?expand=1#diff-8372d553eb3845a04d491ab410b2620aR111).

Additionally, logging period submission errors now.