### PR TITLE
fix: proper slot selection

### DIFF
--- a/src/utils/getCurrentSlotId.js
+++ b/src/utils/getCurrentSlotId.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the Mozilla Public License Version 2.0
  * found in the LICENSE file in the root directory of this source tree.
  */
+const { Period } = require('leap-core');
 
 module.exports = function getCurrentSlotId(slots, height) {
   const activeSlots = slots.filter(s => s);
-  const index = height % activeSlots.length;
+  const [height32aligned] = Period.periodBlockRange(height);
+  const index = Math.floor(height32aligned / 32 % activeSlots.length);
   return activeSlots[index] && activeSlots[index].id;
 };

--- a/src/utils/getCurrentSlotId.test.js
+++ b/src/utils/getCurrentSlotId.test.js
@@ -15,23 +15,97 @@ test('no active slots', () => {
   expect(result).toBeUndefined();
 });
 
-test('1 active slots', () => {
-  const slots = [undefined, { id: 1, owner: ADDR_1 }];
-  expect(getCurrentSlotId(slots, 1)).toBe(1);
-  expect(getCurrentSlotId(slots, 2)).toBe(1);
-  expect(getCurrentSlotId(slots, 3)).toBe(1);
+const expectForSlots = (slots, fixtures) => {
+  fixtures.forEach(({ height, proposingSlot }) =>
+    test(`Period at height ${height} is proposed by slot ${proposingSlot}`, () =>
+      expect(getCurrentSlotId(slots, height)).toBe(proposingSlot)
+    )
+  );
+}
+
+describe('one slot', () => {
+  const slots = [
+    { id: 0, owner: ADDR_1 },
+  ];
+
+  expectForSlots(slots, [
+    { height: 30, proposingSlot: 0 },
+    { height: 31, proposingSlot: 0 },
+    { height: 32, proposingSlot: 0 },
+    { height: 33, proposingSlot: 0 },
+    { height: 63, proposingSlot: 0 },
+    { height: 64, proposingSlot: 0 }
+  ]);
 });
 
-test('several active slots', () => {
+describe('one slot with a gap', () => {
   const slots = [
     undefined,
+    { id: 0, owner: ADDR_1 },
+  ];
+
+  expectForSlots(slots, [
+    { height: 30, proposingSlot: 0 },
+    { height: 31, proposingSlot: 0 },
+    { height: 32, proposingSlot: 0 },
+    { height: 33, proposingSlot: 0 },
+    { height: 63, proposingSlot: 0 },
+    { height: 64, proposingSlot: 0 }
+  ]);
+});
+
+describe('two slots', () => {
+  const slots = [
+    { id: 0, owner: ADDR_1 },
+    { id: 1, owner: ADDR_1 },
+  ];
+
+  expectForSlots(slots, [
+    { height: 30, proposingSlot: 0 },
+    { height: 31, proposingSlot: 0 },
+    { height: 32, proposingSlot: 1 },
+    { height: 33, proposingSlot: 1 },
+    { height: 63, proposingSlot: 1 },
+    { height: 64, proposingSlot: 0 },
+  ]);
+});
+
+describe('three slots', () => {
+  const slots = [
+    { id: 0, owner: ADDR_1 },
     { id: 1, owner: ADDR_1 },
     { id: 2, owner: ADDR_1 },
-    undefined,
-    { id: 4, owner: ADDR_1 },
   ];
-  expect(getCurrentSlotId(slots, 1)).toBe(2);
-  expect(getCurrentSlotId(slots, 2)).toBe(4);
-  expect(getCurrentSlotId(slots, 3)).toBe(1);
-  expect(getCurrentSlotId(slots, 4)).toBe(2);
+
+  expectForSlots(slots, [
+    { height: 30, proposingSlot: 0 },
+    { height: 31, proposingSlot: 0 },
+    { height: 32, proposingSlot: 1 },
+    { height: 33, proposingSlot: 1 },
+    { height: 63, proposingSlot: 1 },
+    { height: 64, proposingSlot: 2 },
+    { height: 65, proposingSlot: 2 },
+    { height: 95, proposingSlot: 2 },
+    { height: 96, proposingSlot: 0 },
+  ]);
+});
+
+describe('two slots with a gap', () => {
+  const slots = [
+    { id: 0, owner: ADDR_1 },
+    undefined,
+    { id: 2, owner: ADDR_1 },
+  ];
+
+  expectForSlots(slots, [
+    { height: 30, proposingSlot: 0 },
+    { height: 31, proposingSlot: 0 },
+    { height: 32, proposingSlot: 2 },
+    { height: 33, proposingSlot: 2 },
+    { height: 63, proposingSlot: 2 },
+    { height: 64, proposingSlot: 0 },
+    { height: 65, proposingSlot: 0 },
+    { height: 95, proposingSlot: 0 },
+    { height: 96, proposingSlot: 2 },
+  ]);
 });


### PR DESCRIPTION
Each active slot becomes proposer at least once per epoch.

See unit tests for fixtures.

Resolves #364
Resolves #31 