### PR TITLE
fix: restarting the validator skips x32nd block from the currentPeriod

### DIFF
--- a/src/block/updatePeriod.js
+++ b/src/block/updatePeriod.js
@@ -12,6 +12,7 @@ const activateSlot = require('../txHelpers/activateSlot');
 const { getAuctionedByAddr } = require('../utils');
 const { logPeriod } = require('../utils/debug');
 const checkEnoughVotes = require('../period/utils/checkEnoughVotes');
+const isReplay = require('../period/utils/isReplay');
 
 module.exports = async (state, chainInfo, bridgeState, sender) => {
   if (bridgeState.pendingPeriod) {
@@ -34,7 +35,7 @@ module.exports = async (state, chainInfo, bridgeState, sender) => {
     }
   }
 
-  if (chainInfo.height % 32 === 0) {
+  if (chainInfo.height % 32 === 0 && !isReplay(bridgeState)) {
     logPeriod('updatePeriod');
     try {
       bridgeState.periodHeights[bridgeState.currentPeriod.merkleRoot()] =

--- a/src/block/updatePeriod.test.js
+++ b/src/block/updatePeriod.test.js
@@ -20,6 +20,7 @@ const SUBMITTED_PERIOD = {
 
 const NON_EXISTENT_PERIOD = {
   prevHash: '0x000001',
+  blockList: ['0x'],
   merkleRoot() {
     return '0x000011';
   },

--- a/src/period/utils/isReplay.js
+++ b/src/period/utils/isReplay.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2018-present, Leap DAO (leapdao.org)
+ *
+ * This source code is licensed under the Mozilla Public License Version 2.0
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = ({ currentPeriod, lastBlocksRoot }) =>
+  !currentPeriod
+  || !currentPeriod.blockList.length
+  || currentPeriod.merkleRoot() === lastBlocksRoot;


### PR DESCRIPTION
State was saved every 32nd block once 32nd block is processed, so on restart currentPeriod is blank and being filled with blocks starting from 33rd and so on.

Proposed solution is to save state before we process 32nd block, thus it will be "replayed" on restart producing correct currentPeriod object. This requires some replay protection for period vote and period submission code triggered every 32nd block as well (implemented here as well)

🍝 

Resolves #366 