### PR TITLE
Send heartbeat every minute

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const BlockTicker = require('./src/utils/BlockTicker');
 const EventsRelay = require('./src/eventsRelay');
 const lotion = require('./lotion');
 const delayedSender = require('./src/txHelpers/delayedSender');
+const heartbeatService = require('./src/heartbeat');
 
 const { logNode, logTendermint } = require('./src/utils/debug');
 
@@ -94,6 +95,8 @@ async function run() {
   app.usePeriod(periodHandler(bridgeState, sender));
 
   const lastGoodState = await bridgeState.loadState();
+
+  heartbeatService(bridgeState, sender);
 
   app.listen(lastGoodState).then(async params => {
     blockTicker.subscribe(eventsRelay.onNewBlock);

--- a/src/api/methods/getUnspent.js
+++ b/src/api/methods/getUnspent.js
@@ -3,11 +3,29 @@ const { omit } = require('lodash');
 const getColor = require('./getColor');
 const { filterUnspent } = require('../../utils');
 
+function othersHeartbeatUtxos(bridgeState) {
+  if (bridgeState.config.heartbeatColor !== undefined && bridgeState.account) {
+    const {
+      currentState: { unspent },
+      account: { address },
+      config: { heartbeatColor },
+    } = bridgeState;
+    return Object.keys(unspent).filter(
+      k =>
+        unspent[k] &&
+        unspent[k].address.toLowerCase() !== address.toLowerCase() &&
+        Number(unspent[k].color) === Number(heartbeatColor)
+    );
+  }
+  return [];
+}
+
 module.exports = async (bridgeState, address, colorOrAddress) => {
-  const unspent = omit(
-    bridgeState.currentState.unspent,
-    Object.keys(bridgeState.exitingUtxos)
-  );
+  const unspent = omit(bridgeState.currentState.unspent, [
+    ...Object.keys(bridgeState.exitingUtxos),
+    ...othersHeartbeatUtxos(bridgeState),
+  ]);
+
   let color = colorOrAddress;
   if (isValidAddress(colorOrAddress)) {
     color = await getColor(bridgeState, colorOrAddress);

--- a/src/api/methods/getUnspent.js
+++ b/src/api/methods/getUnspent.js
@@ -6,6 +6,7 @@ const { filterUnspent } = require('../../utils');
 function othersHeartbeatUtxos(bridgeState) {
   if (
     bridgeState.config.heartbeat &&
+    bridgeState.config.heartbeat.color !== undefined &&
     bridgeState.config.heartbeat.filter &&
     bridgeState.account
   ) {

--- a/src/api/methods/getUnspent.js
+++ b/src/api/methods/getUnspent.js
@@ -4,17 +4,23 @@ const getColor = require('./getColor');
 const { filterUnspent } = require('../../utils');
 
 function othersHeartbeatUtxos(bridgeState) {
-  if (bridgeState.config.heartbeatColor !== undefined && bridgeState.account) {
+  if (
+    bridgeState.config.heartbeat &&
+    bridgeState.config.heartbeat.filter &&
+    bridgeState.account
+  ) {
     const {
       currentState: { unspent },
       account: { address },
-      config: { heartbeatColor },
+      config: {
+        heartbeat: { color },
+      },
     } = bridgeState;
     return Object.keys(unspent).filter(
       k =>
         unspent[k] &&
         unspent[k].address.toLowerCase() !== address.toLowerCase() &&
-        Number(unspent[k].color) === Number(heartbeatColor)
+        Number(unspent[k].color) === Number(color)
     );
   }
   return [];

--- a/src/api/methods/getUnspent.test.js
+++ b/src/api/methods/getUnspent.test.js
@@ -175,13 +175,16 @@ describe('getUnspent', () => {
     expect(unspents).toEqual([]);
   });
 
-  test('omit unspent heartbeat NFTs from other addresses', async () => {
+  test('omit unspent heartbeat NFTs from other addresses by default', async () => {
     const state = bridgeState({
       account: {
         address: A1,
       },
       config: {
-        heartbeatColor: 0,
+        heartbeat: {
+          filter: true,
+          color: 0,
+        },
       },
     });
 
@@ -195,5 +198,35 @@ describe('getUnspent', () => {
 
     const unspentA2 = await getUnspent(state, A2, 0);
     expect(unspentA2).toEqual([]);
+  });
+
+  test('include unspent heartbeat NFTs from other addresses if configured otherwise', async () => {
+    const state = bridgeState({
+      account: {
+        address: A1,
+      },
+      config: {
+        heartbeat: {
+          filter: false,
+          color: 0,
+        },
+      },
+    });
+
+    const unspentA1 = await getUnspent(state, A1, 0);
+    expect(unspentA1).toEqual([
+      {
+        outpoint: out1,
+        output: tx.outputs[1].toJSON(),
+      },
+    ]);
+
+    const unspentA2 = await getUnspent(state, A2, 0);
+    expect(unspentA2).toEqual([
+      {
+        outpoint: out0,
+        output: tx.outputs[0].toJSON(),
+      },
+    ]);
   });
 });

--- a/src/heartbeat/defaults.js
+++ b/src/heartbeat/defaults.js
@@ -1,4 +1,5 @@
 module.exports = {
   period: 60 * 1000,
   periodOnError: 5 * 1000,
+  filter: true,
 };

--- a/src/heartbeat/defaults.js
+++ b/src/heartbeat/defaults.js
@@ -1,0 +1,4 @@
+module.exports = {
+  period: 60 * 1000,
+  periodOnError: 5 * 1000,
+};

--- a/src/heartbeat/defaults.js
+++ b/src/heartbeat/defaults.js
@@ -1,5 +1,14 @@
 module.exports = {
-  period: 60 * 1000,
-  periodOnError: 5 * 1000,
+  // The color must be provided by the configuration
+  color: undefined,
+
+  // Filter out the heartbeat NFT from `plasma_getUnspent`
   filter: true,
+
+  // In milliseconds, time between heartbeats
+  period: 60 * 1000,
+
+  // In milliseconds, time to wait before sending a new heartbeat
+  // if the previous one failed
+  periodOnError: 5 * 1000,
 };

--- a/src/heartbeat/index.js
+++ b/src/heartbeat/index.js
@@ -1,20 +1,20 @@
 const { logNode } = require('../utils/debug');
-const pulse = require('./pulse');
 
-async function loop(bridgeState, sender) {
-  try {
-    await pulse(bridgeState, sender);
-    setTimeout(() => loop(bridgeState, sender), 60000);
-  } catch (e) {
-    logNode('Failed to send heartbeat', e.toString());
-    setTimeout(() => loop(bridgeState, sender), 5000);
-  }
+const loop = require('./loop');
+const defaults = require('./defaults');
+
+function updateConfig({ heartbeat = {} }) {
+  return { ...defaults, ...heartbeat };
 }
 
 module.exports = (bridgeState, sender) => {
-  if (!bridgeState.config.heartbeatColor) {
-    logNode('Cannot find Heartbeat color, liveliness service not started.');
+  bridgeState.config.heartbeat = updateConfig(bridgeState.config);
+  if (bridgeState.config.heartbeat.color) {
+    setTimeout(
+      () => loop(bridgeState, sender),
+      bridgeState.config.heartbeat.period
+    );
   } else {
-    setTimeout(() => loop(bridgeState, sender), 60000);
+    logNode('Cannot find Heartbeat color, liveliness service not started.');
   }
 };

--- a/src/heartbeat/index.js
+++ b/src/heartbeat/index.js
@@ -1,3 +1,21 @@
+// # Behavior of the heartbeat service
+//
+// - If the node **cannot find the heartbeat color in the configuration**,
+// there is nothing it can do and the service is **not started**. A node
+// operator will need to adjust their configuration and restart the node if
+// they want it to start.
+// - If the **color is defined in the configuration** but there is **no NFT
+// available** for the current account, the heartbeat service **is started**
+// - The service will check every `config.heartbeat.period` for an available
+// NFT to push forward (default `60000 ms`), and if found it will create a new
+// transaction to transfer the NFT to the account defined in `account.address`.
+// - If there is an error in pushing forward the NFT transaction, the node will
+// try after `config.heartbeat.periodOnError` to send the transaction again
+// (default `5000 ms`)
+// - If `config.heartbeat.filter` is `true` (this is also the default value),
+// calling the RPC `plasma_getUnspent` will filter out the heartbeat NFT of any
+// account different from `account.address` from the results.
+
 const { logNode } = require('../utils/debug');
 
 const loop = require('./loop');

--- a/src/heartbeat/index.js
+++ b/src/heartbeat/index.js
@@ -1,3 +1,4 @@
+const { logNode } = require('../utils/debug');
 const pulse = require('./pulse');
 
 async function loop(bridgeState, sender) {
@@ -5,14 +6,14 @@ async function loop(bridgeState, sender) {
     await pulse(bridgeState, sender);
     setTimeout(() => loop(bridgeState, sender), 60000);
   } catch (e) {
-    console.error('Failed to send heartbeat', e.toString());
+    logNode('Failed to send heartbeat', e.toString());
     setTimeout(() => loop(bridgeState, sender), 5000);
   }
 }
 
 module.exports = (bridgeState, sender) => {
   if (!bridgeState.config.heartbeatColor) {
-    console.log('Cannot find Heartbeat color, liveliness service not started.');
+    logNode('Cannot find Heartbeat color, liveliness service not started.');
   } else {
     setTimeout(() => loop(bridgeState, sender), 60000);
   }

--- a/src/heartbeat/index.js
+++ b/src/heartbeat/index.js
@@ -1,0 +1,19 @@
+const pulse = require('./pulse');
+
+async function loop(bridgeState, sender) {
+  try {
+    await pulse(bridgeState, sender);
+    setTimeout(() => loop(bridgeState, sender), 60000);
+  } catch (e) {
+    console.error('Failed to send heartbeat', e.toString());
+    setTimeout(() => loop(bridgeState, sender), 5000);
+  }
+}
+
+module.exports = (bridgeState, sender) => {
+  if (!bridgeState.config.heartbeatColor) {
+    console.log('Cannot find Heartbeat color, liveliness service not started.');
+  } else {
+    setTimeout(() => loop(bridgeState, sender), 60000);
+  }
+};

--- a/src/heartbeat/index.test.js
+++ b/src/heartbeat/index.test.js
@@ -1,0 +1,47 @@
+const heartbeat = require('.');
+const defaults = require('./defaults');
+
+const { NFT_COLOR_BASE } = require('../api/methods/constants');
+
+const HEARTBEAT_COLOR = NFT_COLOR_BASE + 112;
+
+jest.useFakeTimers();
+
+describe('Heartbeat', () => {
+  test('Does not start the service if config is missing', async () => {
+    const bridgeStateMock = {
+      config: {
+        heartbeat: {},
+      },
+    };
+    heartbeat(bridgeStateMock);
+    expect(setTimeout).toHaveBeenCalledTimes(0);
+  });
+
+  test('Start the service respect defaults', async () => {
+    const bridgeStateMock = {
+      config: {
+        heartbeat: { color: HEARTBEAT_COLOR },
+      },
+    };
+    heartbeat(bridgeStateMock);
+    expect(bridgeStateMock.config.heartbeat).toEqual({
+      ...defaults,
+      color: HEARTBEAT_COLOR,
+    });
+  });
+
+  test('Start the service if config is correct', async () => {
+    const bridgeStateMock = {
+      config: {
+        heartbeat: { color: HEARTBEAT_COLOR },
+      },
+    };
+    heartbeat(bridgeStateMock);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      defaults.period
+    );
+  });
+});

--- a/src/heartbeat/loop.js
+++ b/src/heartbeat/loop.js
@@ -1,0 +1,15 @@
+const { logNode } = require('../utils/debug');
+const pulse = require('./pulse');
+
+async function loop(bridgeState, sender) {
+  const { period, periodOnError } = bridgeState.config.heartbeat;
+  try {
+    await pulse(bridgeState, sender);
+    setTimeout(() => loop(bridgeState, sender), period);
+  } catch (e) {
+    logNode('Failed to send heartbeat', e.toString());
+    setTimeout(() => loop(bridgeState, sender), periodOnError);
+  }
+}
+
+module.exports = loop;

--- a/src/heartbeat/loop.test.js
+++ b/src/heartbeat/loop.test.js
@@ -1,0 +1,40 @@
+const defaults = require('./defaults');
+const loop = require('./loop');
+const pulse = require('./pulse');
+
+const { NFT_COLOR_BASE } = require('../api/methods/constants');
+
+const HEARTBEAT_COLOR = NFT_COLOR_BASE + 112;
+
+const bridgeStateMock = {
+  config: {
+    heartbeat: { ...defaults, color: HEARTBEAT_COLOR },
+  },
+};
+
+jest.useFakeTimers();
+jest.mock('./pulse');
+
+describe('Loop', () => {
+  test('Waits the correct period if no error happened', async () => {
+    pulse.mockImplementation(async () => null);
+    await loop(bridgeStateMock);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      defaults.period
+    );
+  });
+
+  test('Waits the correct period if error in send happened', async () => {
+    pulse.mockImplementation(async () => {
+      throw new Error('Oopsy poopsy');
+    });
+    await loop(bridgeStateMock);
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(
+      expect.any(Function),
+      defaults.periodOnError
+    );
+  });
+});

--- a/src/heartbeat/pulse.js
+++ b/src/heartbeat/pulse.js
@@ -1,3 +1,4 @@
+const { logNode } = require('../utils/debug');
 const { Tx, Input, Outpoint, Output } = require('leap-core');
 const getUnspent = require('../api/methods/getUnspent');
 
@@ -21,5 +22,7 @@ module.exports = async (bridgeState, { send }) => {
     );
     transfer.signAll(bridgeState.account.privateKey);
     await send(transfer);
+  } else {
+    logNode('Cannot find Heartbeat NFT in UTXO.');
   }
 };

--- a/src/heartbeat/pulse.js
+++ b/src/heartbeat/pulse.js
@@ -1,0 +1,25 @@
+const { Tx, Input, Outpoint, Output } = require('leap-core');
+const getUnspent = require('../api/methods/getUnspent');
+
+module.exports = async (bridgeState, { send }) => {
+  const [nft] = getUnspent(
+    bridgeState,
+    bridgeState.account.address,
+    bridgeState.config.heartbeatColor
+  );
+
+  if (nft) {
+    const transfer = Tx.transfer(
+      [new Input(Outpoint.fromRaw(nft.outpoint))],
+      [
+        new Output(
+          nft.output.value,
+          bridgeState.account.address,
+          bridgeState.config.heartbeatColor
+        ),
+      ]
+    );
+    transfer.signAll(bridgeState.account.privateKey);
+    await send(transfer);
+  }
+};

--- a/src/heartbeat/pulse.test.js
+++ b/src/heartbeat/pulse.test.js
@@ -1,0 +1,63 @@
+const { Tx, Input, Outpoint, Output } = require('leap-core');
+
+const pulse = require('./pulse');
+const getUnspent = require('../api/methods/getUnspent');
+const { NFT_COLOR_BASE } = require('../api/methods/constants');
+
+const ADDR = '0xb8205608d54cb81f44f263be086027d8610f3c94';
+const PRIV =
+  '0x9b63fe8147edb8d251a6a66fd18c0ed73873da9fff3f08ea202e1c0a8ead7311';
+const HEARTBEAT_COLOR = NFT_COLOR_BASE + 112;
+const HEARTBEAT_VALUE =
+  '0x0000000000000000000000000000000000000000000000000000000000001234';
+
+const tx = Tx.transfer(
+  [
+    new Input(
+      new Outpoint(
+        '0x7777777777777777777777777777777777777777777777777777777777777777',
+        0
+      )
+    ),
+  ],
+  [new Output(HEARTBEAT_VALUE, ADDR, HEARTBEAT_COLOR)]
+).signAll(PRIV);
+
+const out0 = new Outpoint(tx.hash(), 0).hex();
+const unspent = [
+  {
+    outpoint: out0,
+    output: tx.outputs[0].toJSON(),
+  },
+];
+
+jest.mock('../api/methods/getUnspent');
+
+const sender = {
+  sendDelayed: jest.fn(() => null),
+  send: jest.fn(() => null),
+};
+
+const bridgeStateMock = {
+  account: {
+    address: ADDR,
+    privateKey: PRIV,
+  },
+  config: {
+    heartbeatColor: HEARTBEAT_COLOR,
+  },
+};
+
+describe('Heartbeat', () => {
+  test('If no Heartbeat NFT is found in UTXO, ignore and move along', async () => {
+    getUnspent.mockImplementation(() => []);
+    await pulse(bridgeStateMock, sender);
+    expect(sender.send).not.toBeCalled();
+  });
+
+  test('If Heartbeat NFT is found in UTXO, pulse to signal liveliness', async () => {
+    getUnspent.mockImplementation(() => unspent);
+    await pulse(bridgeStateMock, sender);
+    expect(sender.send).toBeCalled();
+  });
+});

--- a/src/heartbeat/pulse.test.js
+++ b/src/heartbeat/pulse.test.js
@@ -44,11 +44,11 @@ const bridgeStateMock = {
     privateKey: PRIV,
   },
   config: {
-    heartbeatColor: HEARTBEAT_COLOR,
+    heartbeat: { color: HEARTBEAT_COLOR },
   },
 };
 
-describe('Heartbeat', () => {
+describe('Pulse', () => {
   test('If no Heartbeat NFT is found in UTXO, ignore and move along', async () => {
     getUnspent.mockImplementation(() => []);
     await pulse(bridgeStateMock, sender);


### PR DESCRIPTION
Close #288

This PR adds a new heartbeat service that triggers a transfer of the heartbeat NFT every minute.

There are two new configuration options:
```js
heartbeat: {
  // The color must be provided by the configuration
  color: undefined,

  // Filter out the heartbeat NFT from `plasma_getUnspent`
  filter: true,

  // In milliseconds, time between heartbeats
  period: 60 * 1000,

  // In milliseconds, time to wait before sending a new heartbeat
  // if the previous one failed
  periodOnError: 5 * 1000
}
```

The PR modifies also the behavior of `plasma_getUnspent` to filter out unspent NFTs belonging to other nodes.