### PR TITLE
fix: handle failing calls to sendTransaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "tinyqueue": "^2.0.0",
     "unzip": "^0.1.11",
     "varstruct": "^6.1.1",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.37",
+    "web3-core-promievent": "^1.2.4"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/src/utils/sendTransaction.js
+++ b/src/utils/sendTransaction.js
@@ -16,7 +16,10 @@ module.exports = async (web3, method, to, account, opts = {}) => {
     );
   } catch (e) {
     const methodSig = `${method._method.name}(${method.arguments.join(', ')})`; // eslint-disable-line no-underscore-dangle
-    logNode('[sendTransaction] estimateGas fails, probably failing transaction: ', methodSig);
+    logNode(
+      '[sendTransaction] estimateGas fails, probably failing transaction: ',
+      methodSig
+    );
     const result = new PromiEvent();
     result.reject(e);
     return { receiptPromise: result.eventEmitter };

--- a/src/utils/sendTransaction.js
+++ b/src/utils/sendTransaction.js
@@ -4,13 +4,24 @@
  * This source code is licensed under the Mozilla Public License Version 2.0
  * found in the LICENSE file in the root directory of this source tree.
  */
-
+const PromiEvent = require('web3-core-promievent');
+const { logNode } = require('./debug');
 const getRootGasPrice = require('./getRootGasPrice');
 
 module.exports = async (web3, method, to, account, opts = {}) => {
-  const gas = Math.round(
-    (await method.estimateGas({ from: account.address })) * 1.21
-  );
+  let gas;
+  try {
+    gas = Math.round(
+      (await method.estimateGas({ from: account.address })) * 1.21
+    );
+  } catch (e) {
+    const methodSig = `${method._method.name}(${method.arguments.join(', ')})`; // eslint-disable-line no-underscore-dangle
+    logNode('[sendTransaction] estimateGas fails, probably failing transaction: ', methodSig);
+    const result = new PromiEvent();
+    result.reject(e);
+    return { receiptPromise: result.eventEmitter };
+  }
+
   const gasPrice = await getRootGasPrice(web3).catch(() => null);
   const data = method.encodeABI();
   const tx = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2320,7 +2320,7 @@ eventemitter3@1.1.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"
   integrity sha1-R3hr2qCHyvext15zq8XH1UAVjNA=
 
-eventemitter3@^3.1.2:
+eventemitter3@3.1.2, eventemitter3@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
@@ -7038,6 +7038,14 @@ web3-core-promievent@1.0.0-beta.37:
   dependencies:
     any-promise "1.3.0"
     eventemitter3 "1.1.1"
+
+web3-core-promievent@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz#75e5c0f2940028722cdd21ba503ebd65272df6cb"
+  integrity sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==
+  dependencies:
+    any-promise "1.3.0"
+    eventemitter3 "3.1.2"
 
 web3-core-requestmanager@1.0.0-beta.37:
   version "1.0.0-beta.37"


### PR DESCRIPTION
If given `method` call fails (e.g. tx reverts), `estimateGas` will fail as well.
If not caught, this exception will pop up out of ABCI handler and thus terminate the node process.

Proposed solution: catch the exception and return rejecting PromiEvent.