### PR TITLE
fix: checkEnoughVotes should account for slot gaps

### DIFF
--- a/src/validator/periods/checkEnoughVotes.js
+++ b/src/validator/periods/checkEnoughVotes.js
@@ -14,11 +14,12 @@
  * - `needed` is a minimum number of votes needed for consensus
  */
 module.exports = (blocksRoot, periodProposal, slots = []) => {
+  const activeSlots = slots.filter(s => s);
   const votes =
     periodProposal && periodProposal.blocksRoot === blocksRoot
       ? periodProposal.votes.length
       : 0;
-  const needed = Math.floor((slots.length * 2) / 3) + 1;
+  const needed = Math.floor((activeSlots.length * 2) / 3) + 1;
 
   return {
     result: votes >= needed,

--- a/src/validator/periods/checkEnoughVotes.test.js
+++ b/src/validator/periods/checkEnoughVotes.test.js
@@ -72,4 +72,14 @@ describe('checkEnoughVotes', () => {
       needed: 2,
     });
   });
+
+  test('2/2 is enough for slot list with gap', () => {
+    expect(
+      checkEnoughVotes('0x123', proposal(2), [{ id: 0 }, null, { id: 2 }])
+    ).toEqual({
+      result: true,
+      votes: 2,
+      needed: 2,
+    });
+  });
 });


### PR DESCRIPTION
We want to calculate CAS quorum using the number of _active_ slots only, not epochLength. See leapdao/meta#199 for background.