### PR TITLE
fix(periods): submit only quorum of CAS signatures

### DIFF
--- a/src/validator/periods/submitPeriod.js
+++ b/src/validator/periods/submitPeriod.js
@@ -75,7 +75,8 @@ module.exports = async (
     return defaultResponse;
   }
 
-  const cas = buildCas(periodProposal.votes);
+  const quorumOfVotes = periodProposal.votes.slice(0, needed);
+  const cas = buildCas(quorumOfVotes);
   logPeriod('[submitPeriod] CAS:%s',`0x${cas.toString(16)}`);
 
   if (periodProposal.txHash) {

--- a/src/validator/periods/submitPeriod.test.js
+++ b/src/validator/periods/submitPeriod.test.js
@@ -213,6 +213,31 @@ describe('submitPeriod', () => {
     expect(proposal.txHash).toEqual('0xdeadbeef');
   });
 
+  test('submit only minimum required CAS bitmap', async () => {
+    // 4 validator slots
+    const bridgeState = bridgeStateMock({
+      currentState: {
+        slots: [
+          { id: 0, signerAddr: ADDR },
+          { id: 1, signerAddr: ADDR_1 },
+          { id: 2, signerAddr: ADDR_1 },
+          { id: 3, signerAddr: ADDR_1 }
+        ]
+      },
+    });
+
+    // got 4 validator votes
+    checkEnoughVotes.mockReturnValue({ result: true, votes: 4, needed: 3 });
+    const proposal = periodProposal({
+      votes: [0, 1, 2, 3]
+    });
+
+    await submitPeriod(proposal, bridgeState);
+
+    // build CAS for 3 sigs only (quorum)
+    expect(utils.buildCas).toBeCalledWith([0, 1, 2]);
+  });
+
   test('pass through extra options to sendTransaction', async () => {
     const bridgeState = bridgeStateMock({});
 


### PR DESCRIPTION
Plasma bridge [requires](https://github.com/leapdao/leap-contracts/pull/264/files#diff-a1c254046ad1d0b9aadb7ff8be8273afR452) **strictly** a minimum amount of sigs to be submitted. Otherwise, reverts. This PR adjusts period submission for that.

Related: leapdao/meta#199

Resolves #386 