### PR TITLE
feat: start root chain sync from the last app state

### DIFF
--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -209,7 +209,6 @@ module.exports = class BridgeState {
   }
 
   async init() {
-    logNode('Syncing events...');
     this.lastBlockSynced = await this.db.getLastBlockSynced();
     const genesisBlock = await this.bridgeContract.methods
       .genesisBlockNumber()
@@ -223,17 +222,22 @@ module.exports = class BridgeState {
     const nodeState = (await this.db.getNodeState()) || {};
     this.periodProposal = nodeState.periodProposal || null;
     this.stalePeriodProposal = nodeState.stalePeriodProposal || null;
+    this.lastSeenRootChainBlock =
+      nodeState.lastSeenRootChainBlock || parseInt(genesisBlock, 10);
 
+    logNode(`Syncing events from height ${this.lastSeenRootChainBlock}...`);
     this.eventsSubscription = new ContractsEventsSubscription(
       this.web3,
       contracts,
       this.eventsBuffer,
-      parseInt(genesisBlock, 10)
+      this.lastSeenRootChainBlock
     );
     const blockNumber = await this.web3.eth.getBlockNumber();
     await this.eventsSubscription.init();
     await this.onNewBlock(blockNumber);
-    await this.initBlocks();
+    if (this.lastBlockSynced === 0) {
+      await this.initBlocks();
+    }
 
     if (this.lastBlocksRoot && this.lastPeriodRoot) {
       this.currentPeriod = new Period(this.lastBlocksRoot);
@@ -263,6 +267,7 @@ module.exports = class BridgeState {
   }
 
   async onNewBlock(blockNumber) {
+    this.lastSeenRootChainBlock = blockNumber;
     if (this.eventsBuffer.length === 0) {
       return;
     }
@@ -299,14 +304,17 @@ module.exports = class BridgeState {
   }
 
   async saveNodeState() {
-    await this.db.storeNodeState({
-      periodProposal: this.periodProposal,
-      stalePeriodProposal: this.stalePeriodProposal,
-    });
-
     if (!this.submissions.length) return;
     await this.db.storePeriods(this.submissions).then(() => {
       this.submissions = [];
+    });
+  }
+
+  async savePeriodProposals() {
+    await this.db.storeNodeState({
+      periodProposal: this.periodProposal,
+      stalePeriodProposal: this.stalePeriodProposal,
+      lastSeenRootChainBlock: this.lastSeenRootChainBlock,
     });
   }
 

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -305,13 +305,12 @@ module.exports = class BridgeState {
 
   async saveNodeState() {
     if (!this.submissions.length) return;
-    await this.db.storePeriods(this.submissions).then(() => {
-      this.submissions = [];
-    });
+    await this.db.storePeriods(this.submissions);
+    this.submissions = [];
   }
 
   async savePeriodProposals() {
-    await this.db.storeNodeState({
+    return this.db.storeNodeState({
       periodProposal: this.periodProposal,
       stalePeriodProposal: this.stalePeriodProposal,
       lastSeenRootChainBlock: this.lastSeenRootChainBlock,

--- a/src/validator/periods/startNewPeriod.js
+++ b/src/validator/periods/startNewPeriod.js
@@ -35,6 +35,8 @@ module.exports = async (height, bridgeState) => {
     prevPeriodRoot: bridgeState.lastPeriodRoot || GENESIS,
   };
 
+  bridgeState.savePeriodProposals();
+
   await submitPeriodVote(
     currentPeriodBlocksRoot,
     bridgeState.periodProposal,

--- a/src/validator/periods/startNewPeriod.js
+++ b/src/validator/periods/startNewPeriod.js
@@ -35,7 +35,7 @@ module.exports = async (height, bridgeState) => {
     prevPeriodRoot: bridgeState.lastPeriodRoot || GENESIS,
   };
 
-  bridgeState.savePeriodProposals();
+  await bridgeState.savePeriodProposals();
 
   await submitPeriodVote(
     currentPeriodBlocksRoot,

--- a/src/validator/periods/startNewPeriod.test.js
+++ b/src/validator/periods/startNewPeriod.test.js
@@ -25,6 +25,7 @@ const state = extend => ({
     slots: [{ id: 0 }, { id: 1 }],
   },
   lastPeriodRoot: '0x456',
+  savePeriodProposals: jest.fn(),
   ...extend,
 });
 
@@ -58,6 +59,7 @@ describe('startNewPeriod', () => {
       prevPeriodRoot: GENESIS,
     });
     expect(getCurrentSlotId).toBeCalledWith(bridgeState.currentState.slots, 32);
+    expect(bridgeState.savePeriodProposals).toBeCalled();
     expect(submitPeriodVote).toBeCalledWith(
       '0x123',
       bridgeState.periodProposal,
@@ -69,6 +71,7 @@ describe('startNewPeriod', () => {
     const bridgeState = state();
     await startNewPeriod(31, bridgeState);
     expect(bridgeState.periodProposal).not.toBeDefined();
+    expect(bridgeState.savePeriodProposals).not.toBeCalled();
     expect(submitPeriodVote).not.toBeCalled();
   });
 
@@ -76,6 +79,7 @@ describe('startNewPeriod', () => {
     const bridgeState = state({ isReplay: () => true });
     await startNewPeriod(32, bridgeState);
     expect(bridgeState.periodProposal).not.toBeDefined();
+    expect(bridgeState.savePeriodProposals).not.toBeCalled();
     expect(submitPeriodVote).not.toBeCalled();
   });
 });


### PR DESCRIPTION
We keep the app state, so we don't need to replay everything from the genesis. However,
we kept rereading all the root chain events on each restart. Proposed change: store the last
root chain height processed and resume the sync from that height on restart.

Accompanying change:
- storing period proposals not every block, but once created (every 32 blocks)

Resolves #384 