### PR TITLE
fix(build): fix tendermint download for some x32 platforms

### DIFF
--- a/lotion/bin/download.js
+++ b/lotion/bin/download.js
@@ -71,6 +71,7 @@ function getBinaryDownloadURL(version) {
   };
   const arches = {
     x32: '386',
+    ia32: '386',
     x64: 'amd64',
     arm: 'arm',
     arm64: 'arm',


### PR DESCRIPTION
`download.js` script fails to determine platform in some cases and thus fails to download tendermint

FYI @roleengineer 