### PR TITLE
fix(heartbeat): heartbeat service is not submitting txs

### DIFF
--- a/src/heartbeat/pulse.js
+++ b/src/heartbeat/pulse.js
@@ -6,7 +6,7 @@ module.exports = async (bridgeState, { send }) => {
   const [nft] = await getUnspent(
     bridgeState,
     bridgeState.account.address,
-    bridgeState.config.heartbeatColor
+    bridgeState.config.heartbeat.color
   );
 
   if (nft) {
@@ -16,7 +16,7 @@ module.exports = async (bridgeState, { send }) => {
         new Output(
           nft.output.value,
           bridgeState.account.address,
-          bridgeState.config.heartbeatColor
+          bridgeState.config.heartbeat.color
         ),
       ]
     );

--- a/src/heartbeat/pulse.js
+++ b/src/heartbeat/pulse.js
@@ -3,7 +3,7 @@ const { Tx, Input, Outpoint, Output } = require('leap-core');
 const getUnspent = require('../api/methods/getUnspent');
 
 module.exports = async (bridgeState, { send }) => {
-  const [nft] = getUnspent(
+  const [nft] = await getUnspent(
     bridgeState,
     bridgeState.account.address,
     bridgeState.config.heartbeatColor


### PR DESCRIPTION
Two problems fixed:
- `getUnspent` is async and thus returns Promise. Fixed by `await`ing.
- there are both `heartbeatColor` and `heartbeat.color` config options. Fixed by using only the latter