### PR TITLE
fix: remove deprecated calls and improve unit tests

### DIFF
--- a/src/txHelpers/makeTransfer.js
+++ b/src/txHelpers/makeTransfer.js
@@ -34,8 +34,8 @@ module.exports = async function makeTransfer(
     outpoint: Outpoint.fromRaw(u.outpoint),
   }));
 
-  const inputs = helpers.calcInputs(senderUnspent, from, amount, color);
-  const outputs = helpers.calcOutputs(
+  const inputs = Tx.calcInputs(senderUnspent, from, amount, color);
+  const outputs = Tx.calcOutputs(
     senderUnspent,
     inputs,
     fromAddr,

--- a/src/txHelpers/makeTransfer.js
+++ b/src/txHelpers/makeTransfer.js
@@ -5,7 +5,7 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
-const { helpers, Tx, Outpoint } = require('leap-core');
+const { Tx, Outpoint } = require('leap-core');
 const { filterUnspent } = require('../utils');
 
 /*

--- a/src/utils/getRootGasPrice.test.js
+++ b/src/utils/getRootGasPrice.test.js
@@ -1,4 +1,3 @@
-const Web3 = require('web3');
 const axios = require('axios');
 const getRootGasPrice = require('./getRootGasPrice');
 

--- a/src/utils/getRootGasPrice.test.js
+++ b/src/utils/getRootGasPrice.test.js
@@ -20,9 +20,17 @@ axios.get.mockResolvedValue({
   },
 });
 
+const mockWeb3 = (networkId = 1) => ({
+  eth: {
+    net: {
+      getId: () => networkId,
+    },
+  },
+});
+
 describe('getRootGasPrice', () => {
   describe('mainnet', () => {
-    const web3 = new Web3('https://mainnet.infura.io');
+    const web3 = mockWeb3();
 
     test('reads "fast" gas price by default from gas station API', async () => {
       const result = await getRootGasPrice(web3);
@@ -55,7 +63,14 @@ describe('getRootGasPrice', () => {
   });
 
   test('returns null for non-mainnet networks', async () => {
-    const result = await getRootGasPrice(new Web3('https://rinkeby.infura.io'));
+    const rinkebyWeb3 = {
+      eth: {
+        net: {
+          getId: () => 4,
+        },
+      },
+    };
+    const result = await getRootGasPrice(rinkebyWeb3);
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/leapdao/meta/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

<!-- Concise description of what this PR achieves, including any context. -->
- Resolves #350 by changing `helpers.calcOutputs` to `Tx.calcOutputs` and so on. 
- Mocks web3 in getRootGasPrice unit tests, so that real provider is not used.

## Links to relevant issues or information
Closes #350 
<!-- Link to relevant issues, comments, etc. -->
