### PR TITLE
fix(validator): CAS quorum should take logged out slots into account.

### DIFF
--- a/src/period/index.js
+++ b/src/period/index.js
@@ -7,9 +7,10 @@
 
 const submitPeriod = require('../validator/periods/submitPeriod');
 const { logPeriod } = require('../utils/debug');
+const getActiveSlots = require('../utils/getActiveSlots');
 
 const getNextSlotToProposeFrom = (periodProposal, bridgeState) => {
-  const activeSlots = bridgeState.currentState.slots.filter(s => s);
+  const activeSlots = getActiveSlots(bridgeState.currentState.slots);
   return (periodProposal.proposerSlotId + 1) % activeSlots.length;
 };
 

--- a/src/utils/getActiveSlots.js
+++ b/src/utils/getActiveSlots.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2020-present, Leap DAO (leapdao.org)
+ *
+ * This source code is licensed under the Mozilla Public License Version 2.0
+ * found in the LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = slots => slots.filter(s => s && !s.activationEpoch);

--- a/src/utils/getCurrentSlotId.js
+++ b/src/utils/getCurrentSlotId.js
@@ -5,9 +5,10 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 const { Period } = require('leap-core');
+const getActiveSlots = require('../utils/getActiveSlots');
 
 module.exports = function getCurrentSlotId(slots, height) {
-  const activeSlots = slots.filter(s => s);
+  const activeSlots = getActiveSlots(slots);
   const [height32aligned] = Period.periodBlockRange(height);
   const index = Math.floor((height32aligned / 32) % activeSlots.length);
   return activeSlots[index] && activeSlots[index].id;

--- a/src/validator/periods/checkEnoughVotes.js
+++ b/src/validator/periods/checkEnoughVotes.js
@@ -5,6 +5,8 @@
  * found in the LICENSE file in the root directory of this source tree.
  */
 
+const getActiveSlots = require('../../utils/getActiveSlots');
+
 /**
  * Checks if a given period root voted for by at least 2/3 of validator set
  * @returns {Object} Object with results like
@@ -14,7 +16,7 @@
  * - `needed` is a minimum number of votes needed for consensus
  */
 module.exports = (blocksRoot, periodProposal, slots) => {
-  const activeSlots = slots.filter(s => s);
+  const activeSlots = getActiveSlots(slots);
   const votes =
     periodProposal && periodProposal.blocksRoot === blocksRoot
       ? periodProposal.votes.length

--- a/src/validator/periods/checkEnoughVotes.test.js
+++ b/src/validator/periods/checkEnoughVotes.test.js
@@ -82,4 +82,15 @@ describe('checkEnoughVotes', () => {
       needed: 2,
     });
   });
+
+  test('should not account for logged out slots', () => {
+    // we have 5 slots (CAS quorum 4), but slot 2 is logged out, so the CAS quorum is 3
+    const slotsArray = slots(5);
+    slotsArray[1].activationEpoch = 6;
+    expect(checkEnoughVotes('0x123', proposal(5), slotsArray)).toEqual({
+      result: true,
+      votes: 5,
+      needed: 3,
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

This PR fixes the following issue:

If validator is logged out, but not yet removed from validator set (activation pending), we
need to consider it as non-slot for CAS quorum calculations. Otherwise, plasma rejects the period submission.

E.g. for a validator set of size 5, CAS quorum is 4 (4 votes needed for period submission). However, if one of these validators are in process of logging out, the CAS quorum should be 3 (as if the validator set is of size 4).

We are not logging out validator right away, but rather keep them in the validator set marked as subject for removal. It is needed to give everyone time to possibly challenge this validator.


## Recommendations for testing
examine unit tests

if you feel adventurous you may set up a local network with 5 validators and log one of them out. Though cumbersome and not required
<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information
https://github.com/leapdao/leap-node/issues/368
https://github.com/leapdao/leap-contracts/issues/263
https://github.com/leapdao/leap-node/pull/318
<!-- Link to relevant issues, comments, etc. -->
