### PR TITLE
hotfix: keep re-reading events from the genesis, but don't relay them

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,9 @@ docs
 client.js
 mkdocs.yml
 config.json
+node1/
+node2/
+node3/
+node4/
+node5/
+*.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leap-node",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "main": "index.js",
   "author": "Alex Lunyov <isuntc@gmail.com>",
   "license": "MPL-2.0",

--- a/src/bridgeState.js
+++ b/src/bridgeState.js
@@ -237,7 +237,7 @@ module.exports = class BridgeState {
       this.web3,
       contracts,
       this.eventsBuffer,
-      this.lastSeenRootChainBlock
+      parseInt(genesisBlock, 10)
     );
 
     const blockNumber = await this.web3.eth.getBlockNumber();


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/leapdao/meta/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

Since 6.0.0 leap-node remembers the last root chain block it saw and on restart resume event listening from that block only (See #392). However, the implementation was flawed in a way that it didn't store all the state derived from events, so upon restart that state is lost.

The fix is to re-read all the event to derive the state from, but prevent double relaying of these events using the fix from #392

<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->
One of the effects of missing state was lack of colors on the testnet.


## Links to relevant issues or information

Related to #392
Slack thread: https://leapdao.slack.com/archives/CAAGW85BR/p1587464984027500
<!-- Link to relevant issues, comments, etc. -->
